### PR TITLE
Patch release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ NonlinearSolvers = "f4b8ab15-8e73-4e04-9661-b5912071d22b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-CLIMAParameters = "0.1, 0.2"
+CLIMAParameters = "0.1, 0.2, 0.3"
 DocStringExtensions = "0.8"
 KernelAbstractions = "0.5, 0.6"
 NonlinearSolvers = "0.1"


### PR DESCRIPTION
TurbulenceConvection.jl's CI is broken because this package is limiting CLIMAParameters, which the latest Microphysics patch release depends on. This patch release should (hopefully) fix TC.jl's CI.