### PR TITLE
Upgrade to latest Thermodynamics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  JULIA_VERSION: "1.5.4"
+  JULIA_VERSION: "1.7.0"
   CUDA_VERSION: "10.2"
 
 steps:
@@ -7,9 +7,14 @@ steps:
     key: "init_cpu_env"
     command:
       - "echo $JULIA_DEPOT_PATH"
+      - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project -e 'using Pkg; Pkg.status()'"
+
       - "julia --project=test/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=test/ -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=test/ -e 'using Pkg; Pkg.status()'"
+
     agents:
       config: cpu
       queue: central

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
           - '1.6.0'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.2.4"
+version = "0.3.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
@@ -17,5 +17,5 @@ DocStringExtensions = "0.8"
 KernelAbstractions = "0.5, 0.6, 0.7"
 StaticArrays = "1"
 RootSolvers = "0.2, 0.3"
-Thermodynamics = "0.5, 0.6"
-julia = "1.5"
+Thermodynamics = "0.7"
+julia = "1.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -15,7 +15,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 
 [compat]
-CLIMAParameters = "0.1, 0.2, 0.3"
+CLIMAParameters = "0.1, 0.2, 0.3, 0.4"
 KernelAbstractions = "0.5, 0.6, 0.7"
 StaticArrays = "1"
-Thermodynamics = "0.5"
+Thermodynamics = "0.7"


### PR DESCRIPTION
No interface changes, but the resolver is resulting in issues for julia 1.5, so let's just drop support. Many Clima packages require 1.7 or higher anyway, so there's not much gain in maintaining support for julia 1.5.