### PR TITLE
Widen input types to Real

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -65,7 +65,7 @@ Surface flux conditions, returned from `surface_conditions`.
 
 $(DSE.FIELDS)
 """
-struct SurfaceFluxConditions{FT <: AbstractFloat}
+struct SurfaceFluxConditions{FT <: Real}
     L_MO::FT
     shf::FT
     lhf::FT
@@ -98,7 +98,7 @@ Input container for state variables at the ground level.
 
 $(DSE.FIELDS)
 """
-struct SurfaceValues{FT <: AbstractFloat, A, TS <: TD.ThermodynamicState}
+struct SurfaceValues{FT <: Real, A, TS <: TD.ThermodynamicState}
     z::FT
     u::A
     ts::TS
@@ -113,13 +113,13 @@ Input container for state variables at the first interior node.
 
 $(DSE.FIELDS)
 """
-struct InteriorValues{FT <: AbstractFloat, A, TS <: TD.ThermodynamicState}
+struct InteriorValues{FT <: Real, A, TS <: TD.ThermodynamicState}
     z::FT
     u::A
     ts::TS
 end
 
-abstract type AbstractSurfaceConditions{FT <: AbstractFloat, VI <: InteriorValues, VS <: SurfaceValues} end
+abstract type AbstractSurfaceConditions{FT <: Real, VI <: InteriorValues, VS <: SurfaceValues} end
 
 
 """


### PR DESCRIPTION
This PR widens the input types to Real, so that we can ForwardDiff through SurfaceFluxes.