### PR TITLE
Fix for near-zero LMO values

### DIFF
--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -343,6 +343,14 @@ function obukhov_length end
 
 obukhov_length(sfc::SurfaceFluxConditions) = sfc.L_MO
 
+function non_zero_lmo(L_MO::FT) where {FT}
+    if L_MO == FT(0)
+        return L_MO + eps(FT)
+    else
+        return L_MO + sign(L_MO) * eps(FT)
+    end
+end
+
 function obukhov_length(
     param_set,
     sc::AbstractSurfaceConditions{FT},
@@ -376,7 +384,7 @@ function obukhov_length(
             L_MO = sol.root
         end
     end
-    return L_MO
+    return non_zero_lmo(L_MO)
 end
 
 function obukhov_length(param_set, sc::FluxesAndFrictionVelocity{FT}, uft::UF.AUFT, scheme; kwargs...) where {FT}


### PR DESCRIPTION
# PULL REQUEST

  
## Purpose and Content
Divisions by LMO appear in the equation sets, and result in NaN / nonsensical values in some scenarious. This PR adds a function that catches such cases. 
cc @yairchn @szy21 @jiahe23 

## Benefits and Risks
Benefits: Prevents NaNs with near zero LMO 
Risks: Empirical addition of epsilon perturbation. 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI. (See ClimaAtmos)
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
