### PR TITLE
Relax tolerances and near-zero LMO criteria

### DIFF
--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -311,7 +311,7 @@ end
         uft,
         scheme;
         tol::RootSolvers.AbstractTolerance =
-             RootSolvers.SolutionTolerance(max(1e-2, sqrt(eps))),
+             RootSolvers.SolutionTolerance(max(1e-1, sqrt(eps))),
         maxiter::Int = 100
     )
 
@@ -356,7 +356,7 @@ function obukhov_length(
     sc::AbstractSurfaceConditions{FT},
     uft::UF.AUFT,
     scheme;
-    tol::RS.AbstractTolerance = RS.SolutionTolerance(max(FT(1e-2), sqrt(eps(FT)))),
+    tol::RS.AbstractTolerance = RS.SolutionTolerance(max(FT(1e-1), sqrt(eps(FT)))),
     maxiter::Int = 100,
 ) where {FT}
 

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -345,9 +345,9 @@ obukhov_length(sfc::SurfaceFluxConditions) = sfc.L_MO
 
 function non_zero_lmo(L_MO::FT) where {FT}
     if L_MO == FT(0)
-        return L_MO + eps(FT)
+        return L_MO + sqrt(eps(FT))
     else
-        return L_MO + sign(L_MO) * eps(FT)
+        return L_MO + sign(L_MO) * sqrt(eps(FT))
     end
 end
 


### PR DESCRIPTION
# PULL REQUEST

Relax absolute tolerance on LMO, eps ->  sqrt(eps) in near-zero LMO correction function. 