### PR TITLE
Non-iterative solution for stability parameter in stable boundary layers

### DIFF
--- a/parameters/create_parameters.jl
+++ b/parameters/create_parameters.jl
@@ -6,7 +6,7 @@ import Thermodynamics as TD
 function create_uf_parameters(toml_dict, ::UF.GryanikType)
     FT = CP.float_type(toml_dict)
 
-    aliases = ["Pr_0_Gryanik", "a_m_Gryanik", "a_h_Gryanik", "b_m_Gryanik", "b_h_Gryanik"]
+    aliases = ["Pr_0_Gryanik", "a_m_Gryanik", "a_h_Gryanik", "b_m_Gryanik", "b_h_Gryanik", "ζ_a_Gryanik", "γ_Gryanik"]
 
     pairs = CP.get_parameter_values!(toml_dict, aliases, "UniversalFunctions")
     pairs = (; pairs...) # convert to NamedTuple
@@ -17,24 +17,41 @@ function create_uf_parameters(toml_dict, ::UF.GryanikType)
         a_h = pairs.a_h_Gryanik,
         b_m = pairs.b_m_Gryanik,
         b_h = pairs.b_h_Gryanik,
+        ζ_a = pairs.ζ_a_Gryanik,
+        γ = pairs.γ_Gryanik,
     )
     return UF.GryanikParams{FT}(; pairs...)
 end
 
 function create_uf_parameters(toml_dict, ::UF.BusingerType)
     FT = CP.float_type(toml_dict)
-    aliases = ["Pr_0_Businger", "a_m_Businger", "a_h_Businger"]
+    aliases = ["Pr_0_Businger", "a_m_Businger", "a_h_Businger", "ζ_a_Businger", "γ_Businger"]
 
     pairs = CP.get_parameter_values!(toml_dict, aliases, "UniversalFunctions")
     pairs = (; pairs...) # convert to NamedTuple
 
-    pairs = (; Pr_0 = pairs.Pr_0_Businger, a_m = pairs.a_m_Businger, a_h = pairs.a_h_Businger)
+    pairs = (;
+        Pr_0 = pairs.Pr_0_Businger,
+        a_m = pairs.a_m_Businger,
+        a_h = pairs.a_h_Businger,
+        ζ_a = pairs.ζ_a_Businger,
+        γ = pairs.γ_Businger,
+    )
     return UF.BusingerParams{FT}(; pairs...)
 end
 
 function create_uf_parameters(toml_dict, ::UF.GrachevType)
     FT = CP.float_type(toml_dict)
-    aliases = ["Pr_0_Grachev", "a_m_Grachev", "a_h_Grachev", "b_m_Grachev", "b_h_Grachev", "c_h_Grachev"]
+    aliases = [
+        "Pr_0_Grachev",
+        "a_m_Grachev",
+        "a_h_Grachev",
+        "b_m_Grachev",
+        "b_h_Grachev",
+        "c_h_Grachev",
+        "ζ_a_Grachev",
+        "γ_Grachev",
+    ]
 
     pairs = CP.get_parameter_values!(toml_dict, aliases, "UniversalFunctions")
     pairs = (; pairs...) # convert to NamedTuple
@@ -46,6 +63,8 @@ function create_uf_parameters(toml_dict, ::UF.GrachevType)
         b_m = pairs.b_m_Grachev,
         b_h = pairs.b_h_Grachev,
         c_h = pairs.c_h_Grachev,
+        ζ_a = pairs.ζ_a_Grachev,
+        γ = pairs.γ_Grachev,
     )
     return UF.GrachevParams{FT}(; pairs...)
 end

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -38,5 +38,7 @@ a_m(ps::SurfaceFluxesParameters) = a_m(uf_params(ps))
 a_h(ps::SurfaceFluxesParameters) = a_h(uf_params(ps))
 b_m(ps::SurfaceFluxesParameters) = b_m(uf_params(ps))
 b_h(ps::SurfaceFluxesParameters) = b_h(uf_params(ps))
+ζ_a(ps::SurfaceFluxesParameters) = ζ_a(uf_params(ps))
+γ(ps::SurfaceFluxesParameters) = γ(uf_params(ps))
 
 end

--- a/src/UniversalFunctions.jl
+++ b/src/UniversalFunctions.jl
@@ -80,6 +80,8 @@ a_h(uf::AUF) = uf.params.a_h
 b_m(uf::AUF) = uf.params.b_m
 b_h(uf::AUF) = uf.params.b_h
 c_h(uf::AUF) = uf.params.c_h
+ζ_a(uf::AUF) = uf.params.ζ_a
+γ(uf::AUF) = uf.params.γ
 
 π_group(uf::AUF, ::HeatTransport) = Pr_0(uf)
 π_group(::AUF, ::MomentumTransport) = 1
@@ -92,6 +94,8 @@ Base.@kwdef struct BusingerParams{FT} <: AbstractUniversalFunctionParameters{FT}
     Pr_0::FT
     a_m::FT
     a_h::FT
+    ζ_a::FT
+    γ::FT
 end
 
 """
@@ -187,10 +191,6 @@ function Psi(uf::Businger, ζ, tt::MomentumTransport)
             return -FT(15) * ζ / FT(8)
         end
     else
-        # Note that "1-f^3" in is a typo, it is
-        # supposed to be "1-f_m^3". This was
-        # confirmed by communication with the
-        # author.
         if ζ < 0
             f_m = f_momentum(uf, ζ)
             log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
@@ -238,6 +238,8 @@ Base.@kwdef struct GryanikParams{FT} <: AbstractUniversalFunctionParameters{FT}
     a_h::FT
     b_m::FT
     b_h::FT
+    ζ_a::FT
+    γ::FT
 end
 
 """
@@ -253,6 +255,10 @@ end
     `ψ_m`: Eq. 14
     `ψ_h`: Eq. 14
 
+# Gryanik et al. (2020) functions are used in stable conditions
+# In unstable conditions the functions of Businger (1971) are 
+# assigned by default. 
+
 # Fields
 
 $(DSE.FIELDS)
@@ -266,6 +272,9 @@ end
 struct GryanikType <: AbstractUniversalFunctionType end
 Gryanik() = GryanikType()
 
+f_momentum(uf::Gryanik, ζ) = sqrt(sqrt(1 - 15 * ζ))
+f_heat(uf::Gryanik, ζ) = sqrt(1 - 9 * ζ)
+
 function phi(uf::Gryanik, ζ, tt::MomentumTransport)
     FT = eltype(uf)
     if 0 < ζ
@@ -273,8 +282,8 @@ function phi(uf::Gryanik, ζ, tt::MomentumTransport)
         _b_m = FT(b_m(uf))
         return 1 + (_a_m * ζ) / (1 + _b_m * ζ)^(FT(2 / 3))
     else
-        _a_m = FT(a_m(uf))
-        return _a_m * ζ + 1
+        f_m = f_momentum(uf, ζ)
+        return 1 / f_m
     end
 end
 
@@ -286,9 +295,8 @@ function phi(uf::Gryanik, ζ, tt::HeatTransport)
         _b_h = FT(b_h(uf))
         return _Pr_0 * (1 + (_a_h * ζ) / (1 + _b_h * ζ))
     else
-        _a_h = FT(a_h(uf))
-        _π_group = FT(π_group(uf, tt))
-        return _a_h * ζ / _π_group + 1
+        f_h = f_heat(uf, ζ)
+        return 1 / f_h
     end
 end
 
@@ -299,8 +307,9 @@ function psi(uf::Gryanik, ζ, tt::MomentumTransport)
         _b_m = FT(b_m(uf))
         return -3 * (_a_m / _b_m) * ((1 + _b_m * ζ)^(FT(1 / 3)) - 1)
     else
-        _a_m = FT(a_m(uf))
-        return -_a_m * ζ
+        f_m = f_momentum(uf, ζ)
+        log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
+        return log_term - 2 * atan(f_m) + FT(π) / 2
     end
 end
 
@@ -312,12 +321,60 @@ function psi(uf::Gryanik, ζ, tt::HeatTransport)
         _b_h = FT(b_h(uf))
         return -_Pr_0 * (_a_h / _b_h) * log1p(_b_h * ζ)
     else
-        _a_h = FT(a_h(uf))
-        _π_group = FT(π_group(uf, tt))
-        return -_a_h * ζ / _π_group
+        f_h = f_heat(uf, ζ)
+        return 2 * log((1 + f_h) / 2)
     end
 end
 
+function Psi(uf::Gryanik, ζ, tt::MomentumTransport)
+    FT = eltype(uf)
+    _a_m = FT(a_m(uf))
+    _b_m = FT(b_m(uf))
+    if abs(ζ) < eps(FT)
+        # Psi_m in Eq. A13
+        if ζ >= 0
+            # TODO: Add limit given default parameter combination a_m, b_m
+            return -FT(9) * _a_m * ((_b_m * ζ + FT(1))^(FT(4 / 3)) - 1) / ζ / FT(4) / _b_m^FT(2) - FT(1)
+        else
+            return -FT(15) * ζ / FT(8)
+        end
+    else
+        if ζ < 0
+            f_m = f_momentum(uf, ζ)
+            log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
+            π_term = FT(π) / 2
+            tan_term = 2 * atan(f_m)
+            cubic_term = (1 - f_m^3) / (12 * ζ)
+            return log_term - tan_term + π_term - 1 + cubic_term
+        else
+            return -FT(9) * _a_m * ((_b_m * ζ + FT(1))^(FT(4 / 3)) - 1) / ζ / FT(4) / _b_m^FT(2) - FT(1)
+        end
+    end
+end
+
+function Psi(uf::Gryanik, ζ, tt::HeatTransport)
+    FT = eltype(uf)
+    _a_h = FT(a_h(uf))
+    _b_h = FT(b_h(uf))
+    Pr0 = FT(Pr_0(uf))
+    if abs(ζ) < eps(typeof(uf.L))
+        # Psi_h in Eq. A14
+        # TODO Apply limits
+        if ζ >= 0
+            return -_a_h / _b_h / ζ * Pr0 * ((1 / _b_h + ζ) * log1p(_b_h * ζ) - ζ)
+        else
+            return -9 * ζ / 4
+        end
+    else
+        if ζ >= 0
+            return -_a_h / _b_h / ζ * Pr0 * ((1 / _b_h + ζ) * log1p(_b_h * ζ) - ζ)
+        else
+            f_h = f_heat(uf, ζ)
+            log_term = 2 * log((1 + f_h) / 2)
+            return log_term + 2 * (1 - f_h) / (9 * ζ) - 1
+        end
+    end
+end
 
 #####
 ##### Grachev
@@ -330,6 +387,8 @@ Base.@kwdef struct GrachevParams{FT} <: AbstractUniversalFunctionParameters{FT}
     b_m::FT
     b_h::FT
     c_h::FT
+    ζ_a::FT
+    γ::FT
 end
 
 """
@@ -345,6 +404,11 @@ Equations in reference:
     `ψ_m`: Eq. 14
     `ψ_h`: Eq. 14
 
+# Grachev (2007) functions are applicable in the 
+# stable b.l. regime (ζ >= 0). Businger (1971) functions
+# are applied in the unstable b.l. (ζ<0) regime by
+# default. 
+
 # Fields
 
 $(DSE.FIELDS)
@@ -358,37 +422,37 @@ end
 struct GrachevType <: AbstractUniversalFunctionType end
 Grachev() = GrachevType()
 
+f_momentum(uf::Grachev, ζ) = sqrt(sqrt(1 - 15 * ζ))
+f_heat(uf::Grachev, ζ) = sqrt(1 - 9 * ζ)
+
 function phi(uf::Grachev, ζ, tt::MomentumTransport)
-    if 0 < ζ
+    if ζ > 0
         FT = eltype(uf)
         _a_m = FT(a_m(uf))
         _b_m = FT(b_m(uf))
         return 1 + _a_m * ζ * (1 + ζ)^FT(1 / 3) / (1 + _b_m * ζ)
     else
-        FT = eltype(uf)
-        _a_m = FT(a_m(uf))
-        return _a_m * ζ + 1
+        f_m = f_momentum(uf, ζ)
+        return 1 / f_m
     end
 end
 
 function phi(uf::Grachev, ζ, tt::HeatTransport)
-    if 0 < ζ
+    if ζ > 0
         FT = eltype(uf)
         _a_h = FT(a_h(uf))
         _b_h = FT(b_h(uf))
         _c_h = FT(c_h(uf))
         return 1 + (_a_h * ζ + _b_h * ζ^2) / (1 + _c_h * ζ + ζ^2)
     else
-        FT = eltype(uf)
-        _a_h = FT(a_h(uf))
-        _π_group = FT(π_group(uf, tt))
-        return _a_h * ζ / _π_group + 1
+        f_h = f_heat(uf, ζ)
+        return 1 / f_h
     end
 end
 
 function psi(uf::Grachev, ζ, tt::MomentumTransport)
     FT = eltype(uf)
-    if 0 < ζ
+    if ζ > 0
         _a_m = FT(a_m(uf))
         _b_m = FT(b_m(uf))
         B_m = cbrt(1 / _b_m - 1)
@@ -406,13 +470,14 @@ function psi(uf::Grachev, ζ, tt::MomentumTransport)
         bracket_term = log_term_1 - log_term_2 + 2 * sqrt3 * atan_terms
         return linear_term + _a_m * B_m / (2 * _b_m) * bracket_term
     else
-        _a_m = FT(a_m(uf))
-        return -_a_m * ζ
+        f_m = f_momentum(uf, ζ)
+        log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
+        return log_term - 2 * atan(f_m) + FT(π) / 2
     end
 end
 
 function psi(uf::Grachev, ζ, tt::HeatTransport)
-    if 0 < ζ
+    if ζ > 0
         FT = eltype(uf)
         _Pr_0 = FT(Pr_0(uf))
         _a_h = FT(a_h(uf))
@@ -426,10 +491,8 @@ function psi(uf::Grachev, ζ, tt::HeatTransport)
         term_2 = _b_h / 2 * log1p(_c_h * ζ + ζ^2)
         return -coeff * log_terms - term_2
     else
-        FT = eltype(uf)
-        _a_h = FT(a_h(uf))
-        _π_group = FT(π_group(uf, tt))
-        return -_a_h * ζ / _π_group
+        f_h = f_heat(uf, ζ)
+        return 2 * log((1 + f_h) / 2)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ const sf_params = SurfaceFluxes.Parameters.SurfaceFluxesParameters{
     Thermodynamics.Parameters.ThermodynamicsParameters{FT},
 }(
     0.4f0,
-    SurfaceFluxes.UniversalFunctions.BusingerParams{FT}(0.74f0, 4.7f0, 4.7f0),
+    SurfaceFluxes.UniversalFunctions.BusingerParams{FT}(0.74f0, 4.7f0, 4.7f0, 2.5f0, 4.45f0),
     Thermodynamics.Parameters.ThermodynamicsParameters{FT}(
         273.16f0,
         100000.0f0,
@@ -175,7 +175,7 @@ end
         end
     end
     rdiff_sol = (sol_mat[1, :, :, :] .- sol_mat[2, :, :, :]) ./ sol_mat[1, :, :, :]
-    @test all(x -> x <= sqrt(eps(FT)), rdiff_sol)
+    @test all(x -> x <= sqrt(eps(FT)), abs.(rdiff_sol))
 end
 
 @testset "Test profiles" begin


### PR DESCRIPTION
## Purpose and Content
Following Gryanik et al. (2021) DOI: 10.1029/2021MS002590, we include a non-iterative solution for stability parameter ζ (and therefore Monin-Obukhov length) in cases where ζ >= 0. Design documentation has been updated. 

1. Neutral b.l. tolerance is specified at just one point now (via user interface function `surface_conditions`). Value is kept at cp_d/100 following PR#66.  
2. Keyword argument added to `surface_conditions` to allow user to select whether they want to use the non-iterative procedure specified above. 
3. For stability functions which are only for zeta >= 0, Businger-Dyer functions are applied as the default option in cases with ζ <= 0. 
4. Adds convergence checks for the `Gryanik` and `Grachev` type universal functions. 

## Benefits
Optional removal of dependence on user specified tolerances in ζ >= 0 solutions. Following Gryanik et al. (2021) the modifications are expected to be useful for a wider range of stability parameters ζ if the `Gryanik / Grachev` type stability functions are applied. 
 
## Risks
Effect on existing solutions. Can be mitigated by full integration testing prior to merge. Two changes to user interface via keyword arguments for `tol_neutral` and `noniterative_stable_sol`. 

## Linked Issues
#35 

cc @yairchn @szy21 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
