### PR TITLE
Replace z_in access in profile recovery function

### DIFF
--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -894,7 +894,7 @@ function recover_profile(
     uft::UF.AUFT,
     scheme::Union{FVScheme, FDScheme},
 ) where {FT}
-    @assert isless.(Z, sc.vals_in.z)
+    @assert isless.(Z, z_in(sc))
     uf = UF.universal_func(uft, L_MO, SFP.uf_params(param_set))
     von_karman_const::FT = SFP.von_karman_const(param_set)
     _π_group = FT(UF.π_group(uf, transport))


### PR DESCRIPTION
Cleans up interfaces through function call 
modified:   src/SurfaceFluxes.jl

Replaces the field access for interior grid level with a function. 
Towards changes in RSL models + updated tests in recovery profiles. 


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
