### PR TITLE
use relative or absolute tolerance for obukhov length

### DIFF
--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -261,7 +261,7 @@ end
         param_set::AbstractSurfaceFluxesParameters,
         sc::SurfaceFluxes.AbstractSurfaceConditions{FT},
         scheme::SurfaceFluxes.SolverScheme = FVScheme();
-        tol::RS.AbstractTolerance = RS.SolutionTolerance(FT(Δz(sc) / 50)),
+        tol::RS.AbstractTolerance = RS.RelativeOrAbsoluteSolutionTolerance(FT(Δz(sc) / 50), FT(1e-5)),
         tol_neutral::FT = SFP.cp_d(param_set) / 100,
         maxiter::Int = 10,
         soltype::RS.SolutionType = RS.CompactSolution(),
@@ -290,7 +290,7 @@ function surface_conditions(
     param_set::APS,
     sc::AbstractSurfaceConditions{FT},
     scheme::SolverScheme = FVScheme();
-    tol::RS.AbstractTolerance = RS.SolutionTolerance(FT(Δz(sc) / 50)),
+    tol::RS.AbstractTolerance = RS.RelativeOrAbsoluteSolutionTolerance(FT(Δz(sc) / 50), FT(1e-5)),
     tol_neutral = FT(SFP.cp_d(param_set) / 100),
     maxiter::Int = 10,
     soltype::RS.SolutionType = RS.CompactSolution(),
@@ -317,7 +317,7 @@ end
         sc::AbstractSurfaceConditions,
         uft,
         scheme;
-        tol::RS.AbstractTolerance = RS.SolutionTolerance(FT(Δz(sc) / 50)),
+        tol::RS.AbstractTolerance = RS.RelativeOrAbsoluteSolutionTolerance(FT(Δz(sc) / 50), FT(1e-5)),
         tol_neutral::FT = SFP.cp_d(param_set) / 100,
         maxiter::Int = 10
         soltype::RS.SolutionType = RS.CompactSolution(),
@@ -364,7 +364,7 @@ function obukhov_length(
     sc::AbstractSurfaceConditions{FT},
     uft::UF.AUFT,
     scheme;
-    tol::RS.AbstractTolerance = RS.SolutionTolerance(FT(Δz(sc) / 50)),
+    tol::RS.AbstractTolerance = RS.RelativeOrAbsoluteSolutionTolerance(FT(Δz(sc) / 50), FT(1e-5)),
     tol_neutral = FT(SFP.cp_d(param_set) / 100),
     maxiter::Int = 10,
     soltype::RS.SolutionType = RS.CompactSolution(),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Try to fix #62 and ClimaAtmos [#1225](https://github.com/CliMA/ClimaAtmos.jl/issues/1225)

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
