### PR TITLE
Broadcast parameters with Tuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -9,7 +9,7 @@ const UF = UniversalFunctions
 abstract type AbstractSurfaceFluxesParameters end
 const ASFP = AbstractSurfaceFluxesParameters
 
-Base.broadcastable(ps::ASFP) = Ref(ps)
+Base.broadcastable(ps::ASFP) = tuple(ps)
 
 Base.@kwdef struct SurfaceFluxesParameters{FT, AUFPS <: UF.AbstractUniversalFunctionParameters{FT}, TP} <:
                    AbstractSurfaceFluxesParameters

--- a/src/UniversalFunctions.jl
+++ b/src/UniversalFunctions.jl
@@ -43,8 +43,8 @@ abstract type AbstractTransportType end
 struct MomentumTransport <: AbstractTransportType end
 struct HeatTransport <: AbstractTransportType end
 
-Base.broadcastable(tt::AbstractUniversalFunction) = Ref(tt)
-Base.broadcastable(tt::AbstractTransportType) = Ref(tt)
+Base.broadcastable(tt::AbstractUniversalFunction) = tuple(tt)
+Base.broadcastable(tt::AbstractTransportType) = tuple(tt)
 
 """
     phi


### PR DESCRIPTION
This PR changes broadcasting of thermodynamic parameters from Refs to Tuples, as they are immutable and can be stack allocated to avoid dynamic allocations.

This is technically a breaking change, but only to users who use the package with broadcasting