### PR TITLE
Widen KernelAbstractions compat range

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 DocStringExtensions = "0.8, 0.9"
-KernelAbstractions = "0.5, 0.6, 0.7, 0.8"
+KernelAbstractions = "0.5, 0.6, 0.7, 0.8, 0.9"
 RootSolvers = "0.2, 0.3"
 StaticArrays = "1"
 Thermodynamics = "0.9, 0.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -15,5 +15,5 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-KernelAbstractions = "0.5, 0.6, 0.7, 0.8"
+KernelAbstractions = "0.5, 0.6, 0.7, 0.8, 0.9"
 StaticArrays = "1"


### PR DESCRIPTION
This PR widens the KernelAbstractions (KA) compat range to include version KA 0.9 so that ClimaAtmos can update from CUDA 4.0.1 to 4.2.0:

```
julia> Pkg.add(Pkg.PackageSpec(;name="CUDA", version="4.2.0"))
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package KernelAbstractions [63c18a36]:
 KernelAbstractions [63c18a36] log:
 ├─possible versions are: 0.1.0-0.9.4 or uninstalled
 ├─restricted by compatibility requirements with Thermodynamics [b60c26fb] to versions: 0.7.0-0.9.4
 │ └─Thermodynamics [b60c26fb] log:
 │   ├─possible versions are: 0.2.0-0.10.2 or uninstalled
 │   └─restricted to versions 0.10 by ClimaAtmos [b2c96348], leaving only versions 0.10.0-0.10.2
 │     └─ClimaAtmos [b2c96348] log:
 │       ├─possible versions are: 0.13.0 or uninstalled
 │       └─ClimaAtmos [b2c96348] is fixed to version 0.13.0
 ├─restricted by compatibility requirements with CUDA [052768ef] to versions: 0.9.2-0.9.4
 │ └─CUDA [052768ef] log:
 │   ├─possible versions are: 0.1.0-4.2.0 or uninstalled
 │   ├─restricted to versions * by ClimaAtmos [b2c96348], leaving only versions 0.1.0-4.2.0
 │   │ └─ClimaAtmos [b2c96348] log: see above
 │   └─restricted to versions 4.2.0 by an explicit requirement, leaving only versions 4.2.0
 └─restricted by compatibility requirements with SurfaceFluxes [49b00bb7] to versions: 0.5.0-0.8.6 — no versions left
   └─SurfaceFluxes [49b00bb7] log:
     ├─possible versions are: 0.1.0-0.6.2 or uninstalled
     └─restricted to versions 0.6 by ClimaAtmos [b2c96348], leaving only versions 0.6.0-0.6.2
       └─ClimaAtmos [b2c96348] log: see above
```