### PR TITLE
Move Richardson number calculation to a separate function

### DIFF
--- a/docs/src/plot_universal_functions.jl
+++ b/docs/src/plot_universal_functions.jl
@@ -7,7 +7,7 @@ import CLIMAParameters
 const CP = CLIMAParameters
 
 include(joinpath(pkgdir(SurfaceFluxes), "parameters", "create_parameters.jl"))
-const FT = Float32;
+FT = Float32;
 toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
 
 import Plots

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -357,6 +357,11 @@ function non_zero(value::FT) where {FT}
     end
 end
 
+
+function compute_richardson_number(sc::AbstractSurfaceConditions{FT}, DSEᵥ_in::FT, DSEᵥ_sfc::FT, grav::FT) where {FT}
+    return (grav * z_in(sc) * (DSEᵥ_in - DSEᵥ_sfc)) / (DSEᵥ_sfc * (windspeed(sc))^2)
+end
+
 function obukhov_length(
     param_set,
     sc::AbstractSurfaceConditions{FT},
@@ -379,7 +384,7 @@ function obukhov_length(
         ### Analytical Solution 
         ### Gryanik et al. (2021)
         ### DOI: 10.1029/2021MS002590)
-        Ri_b = (grav * z_in(sc) * ΔDSEᵥ) / (DSEᵥ_sfc * (windspeed(sc))^2)
+        Ri_b = compute_richardson_number(sc, DSEᵥ_in, DSEᵥ_sfc, grav)
         @assert Ri_b >= FT(0)
         ϵₘ = FT(Δz(sc) / z0(sc, UF.MomentumTransport()))
         ϵₕ = FT(Δz(sc) / z0(sc, UF.HeatTransport()))
@@ -539,7 +544,7 @@ compute_bstar(param_set, L_MO, sc::Fluxes, uft, scheme) =
     compute_ustar(
         param_set::AbstractSurfaceFluxesParameters,
         L_MO,
-        sc::AbstractSufaceCondition,
+        sc::AbstractSurfaceCondition,
         uft,
         scheme
     )

--- a/test/test_convergence.jl
+++ b/test/test_convergence.jl
@@ -216,8 +216,8 @@ end
         [UF.BusingerType(), UF.GryanikType(), UF.GrachevType(), UF.BeljaarsType(), UF.HoltslagType(), UF.ChengType()]
         for FT in [Float32, Float64]
             for profile_type in [DryProfiles(), MoistEquilProfiles()]
-                profiles_sfc, profiles_int = generate_profiles(FT, profile_type; uf_type = uf_type)
-                scheme = [SF.FVScheme(), SF.FDScheme()]
+                profiles_sfc, profiles_int, param_set = generate_profiles(FT, profile_type; uf_type=uf_type)
+                scheme = [SF.FDScheme()]
                 z0_momentum = Array{FT}(range(1e-6, stop = 1e-1, length = 2))
                 z0_thermal = Array{FT}(range(1e-6, stop = 1e-1, length = 2))
                 maxiter = 10

--- a/test/test_profiles.jl
+++ b/test/test_profiles.jl
@@ -12,7 +12,7 @@ import UnPack
 const TD = Thermodynamics
 
 include(joinpath(pkgdir(SurfaceFluxes), "parameters", "create_parameters.jl"))
-const FT = Float32;
+FT = Float32;
 toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
 param_set = create_parameters(toml_dict, UF.BusingerType())
 thermo_params = SFP.thermodynamics_params(param_set)

--- a/test/test_universal_functions.jl
+++ b/test/test_universal_functions.jl
@@ -11,10 +11,9 @@ import CLIMAParameters
 const CP = CLIMAParameters
 
 include(joinpath(pkgdir(SurfaceFluxes), "parameters", "create_parameters.jl"))
-const FT = Float32;
+FT = Float64;
 toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
 param_set = create_parameters(toml_dict, UF.BusingerType())
-
 universal_functions(uft, L) = UF.universal_func(uft, L, create_uf_parameters(toml_dict, uft))
 
 # TODO: Right now, we test these functions for


### PR DESCRIPTION
Refactor computation of bulk-Richardson number to its own separate function. 
Linked issue : https://github.com/CliMA/SurfaceFluxes.jl/issues/111

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
