### PR TITLE
bump down compat req. for Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -17,4 +17,4 @@ KernelAbstractions = "0.5, 0.6, 0.7, 0.8, 0.9"
 RootSolvers = "0.2, 0.3"
 StaticArrays = "1"
 Thermodynamics = "0.11"
-julia = "1.9"
+julia = "1.6"


### PR DESCRIPTION
We are still running some of our ci on Julia 1.8 in ClimaAtmos. So we can't restrict SurfaceFluxes to 1.9
