### PR TITLE
Remove dependence on StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,13 +8,11 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 DocStringExtensions = "0.8, 0.9"
 KernelAbstractions = "0.5, 0.6, 0.7, 0.8, 0.9"
 RootSolvers = "0.2, 0.3, 0.4"
-StaticArrays = "1"
 Thermodynamics = "0.11"
 julia = "1.9"

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -28,9 +28,6 @@ const DSE = DocStringExtensions
 import Thermodynamics
 const TD = Thermodynamics
 
-import StaticArrays
-const SA = StaticArrays
-
 include("UniversalFunctions.jl")
 import .UniversalFunctions
 const UF = UniversalFunctions

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,7 +10,6 @@ NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SurfaceFluxes = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -19,4 +18,3 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 KernelAbstractions = "0.5, 0.6, 0.7, 0.8, 0.9"
-StaticArrays = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,6 @@ import Thermodynamics
 using SurfaceFluxes
 const SF = SurfaceFluxes
 const SFP = SF.Parameters
-using StaticArrays
 import KernelAbstractions: CPU
 
 include(joinpath(pkgdir(SurfaceFluxes), "parameters", "create_parameters.jl"))
@@ -64,8 +63,8 @@ ArrayType = Array
         ts_sfc = TD.PhaseEquil_ρθq(thermo_params, ρ_sfc, θ_sfc[ii], qt_sfc)
         ts_in = TD.PhaseEquil_ρθq(thermo_params, ρ_in, θ[ii], qt_in)
 
-        state_sfc = SF.StateValues(FloatType(0), SVector{2, FloatType}(0, 0), ts_sfc)
-        state_in = SF.StateValues(z[ii], SVector{2, FloatType}(speed[ii], 0), ts_in)
+        state_sfc = SF.StateValues(FloatType(0), (FloatType(0), FloatType(0)), ts_sfc)
+        state_in = SF.StateValues(z[ii], (FloatType(speed[ii]), FloatType(0)), ts_in)
 
         # State containers
         z0m = z0[ii]

--- a/test/test_convergence.jl
+++ b/test/test_convergence.jl
@@ -11,7 +11,6 @@ const CP = CLIMAParameters
 include(joinpath(pkgdir(SurfaceFluxes), "parameters", "create_parameters.jl"))
 
 using Statistics
-using StaticArrays
 using Thermodynamics
 using Thermodynamics.TemperatureProfiles
 using Thermodynamics.TestedProfiles

--- a/test/test_profiles.jl
+++ b/test/test_profiles.jl
@@ -4,7 +4,6 @@ import SurfaceFluxes
 const SF = SurfaceFluxes
 import SurfaceFluxes.UniversalFunctions as UF
 using Statistics
-using StaticArrays
 import Thermodynamics
 import ArtifactWrappers
 const AW = ArtifactWrappers
@@ -96,8 +95,8 @@ for f in files
     ts_sfc = TD.PhaseEquil_ρθq(thermo_params, ρ_sfc, θ_sfc, qt_sfc)
     ts_in = TD.PhaseEquil_ρθq(thermo_params, ρ_in, θ_in, qt_in)
 
-    u_in = SVector{2, FT}(u_in, v_in)
-    u_sfc = SVector{2, FT}(u_sfc, v_sfc)
+    u_in = (FT(u_in), FT(v_in))
+    u_sfc = (FT(u_sfc), FT(v_sfc))
 
     state_sfc = SF.StateValues(z_sfc, u_sfc, ts_sfc)
     state_in = SF.StateValues(z_in, u_in, ts_in)


### PR DESCRIPTION
StaticArrays support left-over from ClimateMachine.
This is unnecessary within the SurfaceFluxes package. Removes dependence on StaticArrays and updates tests to use tuples. 
