### PR TITLE
Hide code branch that leads to GPU incompatibilities in Julia 1.10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,7 @@ env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
   OPENBLAS_NUM_THREADS: 1
   JULIA_NVTX_CALLBACKS: gc
+  JULIA_CPU_TARGET: 'broadwell;skylake;icelake;cascadelake;epyc'
   OMPI_MCA_opal_warn_on_missing_libcuda: 0
   MPITRAMPOLINE_LIB: '/groups/esm/software/MPIwrapper/ompi4.1.5_cuda-12.2/lib64/libmpiwrapper.so'
   MPITRAMPOLINE_MPIEXEC: '/groups/esm/software/MPIwrapper/ompi4.1.5_cuda-12.2/bin/mpiwrapperexec'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A package for computing surface fluxes between the atmosphere, ocean and land mo
 | **Documentation**    | [![dev][docs-dev-img]][docs-dev-url]          |
 | **GHA CI**           | [![gha ci][gha-ci-img]][gha-ci-url]           |
 | **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
-| **Bors enabled**     | [![bors][bors-img]][bors-url]                 |
 
 [docs-bld-img]: https://github.com/CliMA/SurfaceFluxes.jl/actions/workflows/docs.yml/badge.svg
 [docs-bld-url]: https://github.com/CliMA/SurfaceFluxes.jl/actions/workflows/docs.yml
@@ -21,7 +20,3 @@ A package for computing surface fluxes between the atmosphere, ocean and land mo
 
 [codecov-img]: https://codecov.io/gh/CliMA/SurfaceFluxes.jl/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/CliMA/SurfaceFluxes.jl
-
-[bors-img]: https://bors.tech/images/badge_small.svg
-[bors-url]: https://app.bors.tech/repositories/35311
-

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -291,7 +291,12 @@ function surface_conditions(
     noniterative_stable_sol::Bool = true,
 ) where {FT}
     uft = SFP.universal_func_type(param_set)
-    L_MO = obukhov_length(param_set, sc, uft, scheme; tol, tol_neutral, maxiter, soltype, noniterative_stable_sol)
+    # FIXME: Workaround for julia 1.10 and GPUs.
+    if sc isa Coefficients || sc isa FluxesAndFrictionVelocity
+        L_MO = obukhov_length(param_set, sc, uft, scheme)
+    else
+        L_MO = obukhov_length(param_set, sc, uft, scheme; tol, tol_neutral, maxiter, soltype, noniterative_stable_sol)
+    end
     ustar = compute_ustar(param_set, L_MO, sc, uft, scheme)
     Cd = momentum_exchange_coefficient(param_set, L_MO, sc, uft, scheme, tol_neutral)
     Ch = heat_exchange_coefficient(param_set, L_MO, sc, uft, scheme, tol_neutral)


### PR DESCRIPTION
As of CUDA 5.1.1, there are some issues with ClimaAtmos and Julia 1.10.
It seems that the issue is with this particular function and the error
is due to added calles to gc_frame functions that cannot be compiled on
a GPU.

For unknown reasons, the code compiles when we remove the keyword
arguments. While the issue is being investigated, we can work around it
by excluding the offending branch

Includes house cleaning.
