### PR TITLE
Update to ClimaParameter v0.9.0, Thermodynamics v0.12.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,8 @@ CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 CreateParametersExt = "CLIMAParameters"
 
 [compat]
-CLIMAParameters = "0.8"
+CLIMAParameters = "0.9"
 DocStringExtensions = "0.8, 0.9"
 RootSolvers = "0.2, 0.3, 0.4"
-Thermodynamics = "0.11.5"
+Thermodynamics = "0.12"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -16,5 +16,4 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 Aqua = "0.8"
-CLIMAParameters = "0.8"
 KernelAbstractions = "0.9"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -19,9 +19,9 @@ using Aqua
     # then please lower the limit based on the new number of ambiguities.
     # We're trying to drive this number down to zero to reduce latency.
     # Uncomment for debugging:
-    for method_ambiguity in ambs
-        @show method_ambiguity
-    end
+    # for method_ambiguity in ambs
+    #     @show method_ambiguity
+    # end
     @test length(ambs) ≤ 0
 end
 

--- a/test/test_convergence.jl
+++ b/test/test_convergence.jl
@@ -69,7 +69,6 @@ function assemble_surface_conditions(prof_int, prof_sfc, ts_int, ts_sfc, z0m, z0
 end
 
 function check_over_dry_states(
-    param_set,
     ::Type{FT},
     profiles_int,
     profiles_sfc,
@@ -80,6 +79,7 @@ function check_over_dry_states(
     tol_neutral,
     gryanik_noniterative::Bool,
 ) where {FT}
+    param_set = SFP.SurfaceFluxesParameters(FT, UF.BusingerParams)
     counter = [0, 0, 0] # Stable, Unstable, Neutral
     @inbounds for (ii, prof_int) in enumerate(profiles_int)
         @inbounds for (jj, prof_sfc) in enumerate(profiles_sfc)
@@ -137,8 +137,7 @@ function check_over_dry_states(
 end
 
 function check_over_moist_states(
-    param_set,
-    FT::DataType,
+    ::Type{FT},
     profiles_int,
     profiles_sfc,
     scheme,
@@ -147,7 +146,8 @@ function check_over_moist_states(
     maxiter,
     tol_neutral,
     gryanik_noniterative::Bool,
-)
+) where {FT}
+    param_set = SFP.SurfaceFluxesParameters(FT, BusingerParams)
     counter = [0, 0, 0] # Stable, Unstable, Neutral
     @inbounds for (ii, prof_int) in enumerate(profiles_int)
         @inbounds for (jj, prof_sfc) in enumerate(profiles_sfc)
@@ -233,7 +233,6 @@ end
                 tol_neutral = FT(SF.Parameters.cp_d(param_set) / 10)
                 for iteration_option in [true]
                     counter = check_over_dry_states(
-                        param_set,
                         FT,
                         profiles_int,
                         profiles_sfc,
@@ -245,7 +244,6 @@ end
                         iteration_option,
                     )
                     counter = check_over_moist_states(
-                        param_set,
                         FT,
                         profiles_int,
                         profiles_sfc,


### PR DESCRIPTION
This PR fixes an issue where the param set with the wrong float type was being passed in to tests. I'm not sure how this was passing before.

I also commented out a portion of an Aqua test that is only meant to be uncommented for debugging (unbound args).