### PR TITLE
Remove unnecessary typecasts and add promotion to support Dual numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -6,13 +6,13 @@ const TDPS = TD.Parameters.ThermodynamicsParameters
 import ..UniversalFunctions
 const UF = UniversalFunctions
 
-abstract type AbstractSurfaceFluxesParameters end
+abstract type AbstractSurfaceFluxesParameters{FT} end
 const ASFP = AbstractSurfaceFluxesParameters
 
 Base.broadcastable(ps::ASFP) = tuple(ps)
 
-Base.@kwdef struct SurfaceFluxesParameters{FT, AUFPS <: UF.AbstractUniversalFunctionParameters{FT}, TP} <:
-                   AbstractSurfaceFluxesParameters
+Base.@kwdef struct SurfaceFluxesParameters{FT, AUFPS <: UF.AbstractUniversalFunctionParameters{FT}, TP <: TDPS{FT}} <:
+                   AbstractSurfaceFluxesParameters{FT}
     von_karman_const::FT
     ufp::AUFPS
     thermo_params::TP

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -63,9 +63,7 @@ struct SurfaceFluxConditions{FT <: Real}
 end
 
 SurfaceFluxConditions(L_MO, shf, lhf, buoy_flux, ρτxz, ρτyz, ustar, Cd, Ch, E) =
-    SurfaceFluxConditions(
-        promote(L_MO, shf, lhf, buoy_flux, ρτxz, ρτyz, ustar, Cd, Ch, E)...,
-    )
+    SurfaceFluxConditions(promote(L_MO, shf, lhf, buoy_flux, ρτxz, ρτyz, ustar, Cd, Ch, E)...)
 
 function Base.show(io::IO, sfc::SurfaceFluxConditions)
     println(io, "----------------------- SurfaceFluxConditions")
@@ -294,12 +292,7 @@ function surface_conditions(
     noniterative_stable_sol::Bool = true,
 ) where {FT}
     uft = SFP.universal_func_type(param_set)
-    # FIXME: Workaround for julia 1.10 and GPUs.
-    if sc isa Coefficients || sc isa FluxesAndFrictionVelocity
-        L_MO = obukhov_length(param_set, sc, uft, scheme)
-    else
-        L_MO = obukhov_length(param_set, sc, uft, scheme; tol, tol_neutral, maxiter, soltype, noniterative_stable_sol)
-    end
+    L_MO = obukhov_length(param_set, sc, uft, scheme; tol, tol_neutral, maxiter, soltype, noniterative_stable_sol)
     ustar = compute_ustar(param_set, L_MO, sc, uft, scheme)
     Cd = momentum_exchange_coefficient(param_set, L_MO, sc, uft, scheme, tol_neutral)
     Ch = heat_exchange_coefficient(param_set, L_MO, sc, uft, scheme, tol_neutral)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR is a followup to CliMA/RootSolvers.jl#50, CliMA/Thermodynamics.jl#199, and CliMA/Thermodynamics.jl#200. Together with those changes, this should allow us to pass `ForwardDiff.Dual` numbers through the ClimaAtmos implicit tendency.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Remove unused `FT` type variables from method definitions
- Drop typecasts to `FT` where the argument is derived from the parameter set
- For typecasts to `FT` where the argument is a `Float64` literal (`0.01` or `Inf`), infer `FT` from the parameter set instead of the surface conditions (which might contain a mixture of ordinary numbers and `Dual` numbers)
- Add a restriction to the definition of `SurfaceFluxesParameters` to ensure that the parameter set has an internally consistent `FT` type
- Add a constructor to `SurfaceFluxConditions` that promotes all of its arguments to a common type (for mixtures of ordinary numbers and `Dual` numbers, this will promote everything to `Dual`s)
- Fix a typo: replace `Δz(sc) ./ ζₛ` with `Δz(sc) / ζₛ` (both values are scalars, so we do not need to broadcast here)
  - Fixes #144
- Fix a type instability: replace `π_group⁻¹ = 1 / π_group; return π_group⁻¹ * von_karman_const / Σterms` with `return von_karman_const / (π_group * Σterms)` (since `π_group` is 1, computing `π_group⁻¹` results in a `Float64` type instability)
- Bump the minor version number

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
