### PR TITLE
Fix kwargs issue on GPUs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -292,7 +292,7 @@ function surface_conditions(
     noniterative_stable_sol::Bool = true,
 ) where {FT}
     uft = SFP.universal_func_type(param_set)
-    L_MO = obukhov_length(param_set, sc, uft, scheme; tol, tol_neutral, maxiter, soltype, noniterative_stable_sol)
+    L_MO = obukhov_length(param_set, sc, uft, scheme, tol, tol_neutral, maxiter, soltype, noniterative_stable_sol)
     ustar = compute_ustar(param_set, L_MO, sc, uft, scheme)
     Cd = momentum_exchange_coefficient(param_set, L_MO, sc, uft, scheme, tol_neutral)
     Ch = heat_exchange_coefficient(param_set, L_MO, sc, uft, scheme, tol_neutral)
@@ -311,11 +311,11 @@ end
         param_set::AbstractSurfaceFluxesParameters,
         sc::AbstractSurfaceConditions,
         uft,
-        scheme;
-        tol::RS.AbstractTolerance = RS.RelativeSolutionTolerance(FT(0.01)),
-        tol_neutral = SFP.cp_d(param_set) / 100,
-        maxiter::Int = 10
-        soltype::RS.SolutionType = RS.CompactSolution(),
+        scheme,
+        tol,
+        tol_neutral,
+        maxiter,
+        soltype,
     )
 
 Compute and return the Monin-Obukhov lengthscale (LMO).
@@ -394,12 +394,12 @@ function obukhov_length(
     param_set::APS{FT},
     sc::Union{Fluxes, ValuesOnly},
     uft::UF.AUFT,
-    scheme;
-    tol::RS.AbstractTolerance = RS.RelativeSolutionTolerance(FT(0.01)),
-    tol_neutral = SFP.cp_d(param_set) / 100,
-    maxiter::Int = 10,
-    soltype::RS.SolutionType = RS.CompactSolution(),
-    noniterative_stable_sol::Bool = true,
+    scheme,
+    tol,
+    tol_neutral,
+    maxiter,
+    soltype,
+    noniterative_stable_sol,
 ) where {FT}
     thermo_params = SFP.thermodynamics_params(param_set)
     ufparams = SFP.uf_params(param_set)
@@ -454,11 +454,11 @@ function obukhov_length(
     end
 end
 
-function obukhov_length(param_set, sc::FluxesAndFrictionVelocity, uft::UF.AUFT, scheme; kwargs...)
+function obukhov_length(param_set, sc::FluxesAndFrictionVelocity, uft::UF.AUFT, scheme, args...)
     return -sc.ustar^3 / SFP.von_karman_const(param_set) / non_zero(compute_buoyancy_flux(param_set, sc, scheme))
 end
 
-function obukhov_length(param_set, sc::Coefficients, uft::UF.AUFT, scheme; kwargs...)
+function obukhov_length(param_set, sc::Coefficients, uft::UF.AUFT, scheme, args...)
     lhf = latent_heat_flux(param_set, sc.Ch, sc, scheme)
     shf = sensible_heat_flux(param_set, sc.Ch, sc, scheme)
     ustar = sqrt(sc.Cd) * windspeed(sc)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
It looks like the fix to #144 applied in #157 did not work in ClimaAtmos (see [this build](https://buildkite.com/clima/climaatmos-ci/builds/16849)), and several test cases now have a garbage collection instruction that is breaking GPU compilation. Replacing `kwargs` in some methods of the `obukhov_length` function with regular `args` fixes this issue. Since these are internal methods, they probably shouldn't have `kwargs` anyway.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
