### PR TITLE
Update version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.11.0"
+version = "0.12.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
Includes changes to `non_zero` function and some simplified conditional expressions. `ClimaAtmos` results with this update are available via buildkite gpu-longrun results:  
https://buildkite.com/clima/climaatmos-gpulongruns/builds/287#_