### PR TITLE
Test iterative solve with current constructors 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,11 @@ authors = ["Climate Modeling Alliance"]
 version = "0.12.0"
 
 [deps]
+ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
-ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 
 [weakdeps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -16,6 +16,7 @@
 """
 module SurfaceFluxes
 
+using Statistics:norm
 
 import RootSolvers
 const RS = RootSolvers
@@ -236,6 +237,13 @@ z0(sc::AbstractSurfaceConditions, ::UF.MomentumTransport) = sc.z0m
 
 Δu1(sc::AbstractSurfaceConditions) = sc.state_in.u[1] - sc.state_sfc.u[1]
 Δu2(sc::AbstractSurfaceConditions) = sc.state_in.u[2] - sc.state_sfc.u[2]
+
+θ_in(param_set::APS, sc::AbstractSurfaceConditions) =
+    TD.virtual_temperature(SFP.thermodynamics_params(param_set), ts_in(sc))
+θ_sfc(param_set::APS, sc::AbstractSurfaceConditions) =
+    TD.virtual_temperature(SFP.thermodynamics_params(param_set), ts_sfc(sc))
+Δθ(param_set::APS, sc::AbstractSurfaceConditions) = θ_in(param_set, sc) - θ_sfc(param_set, sc)
+
 
 qt_in(param_set::APS, sc::AbstractSurfaceConditions) =
     TD.total_specific_humidity(SFP.thermodynamics_params(param_set), ts_in(sc))
@@ -471,30 +479,32 @@ args
 
 return
 """
-@inline function refine_similarity_variables(estimated_characteristic_scales, 
+function refine_similarity_variables(estimated_characteristic_scales, 
                                              velocity_scale,
-                                             similarity_theory,
-                                             surface_state,
+                                             surface_states,
                                              atmos_boundary_layer_height,
                                              thermodynamics_parameters,
                                              param_set)
 
+    surface_state = surface_states.state_sfc
+    interior_state = surface_states.state_in
+
     gravitational_acceleration = SFP.grav(param_set)
-    von_karman_constant = SFP.von_karman_constant(param_set)
+    von_karman_constant = SFP.von_karman_const(param_set)
     # "initial" scales because we will recompute them
-    u★= estimated_characteristic_scales.momentum
-    θ★ = estimated_characteristic_scales.temperature
-    q★ = estimated_characteristic_scales.water_vapor
+    u★ = estimated_characteristic_scales[1]
+    θ★ = estimated_characteristic_scales[2]
+    q★ = estimated_characteristic_scales[3]
     uτ = velocity_scale
 
     # Similarity functions from Edson et al. (2013)
     # Extract roughness lengths
-    ℓu = z0(sc, UF.MomentumTransport())
-    ℓθ = z0(sc, UF.HeatTransport())
-    ℓq = z0(sc, UF.HeatTransport())
-    β  = similarity_theory.gustiness_parameter # FT(6.5)
+    ℓu = z0(surface_states, UF.MomentumTransport())
+    ℓθ = z0(surface_states, UF.HeatTransport())
+    ℓq = z0(surface_states, UF.HeatTransport())
+    β  = eltype(uτ)(6.5)
 
-    h  = Δz(sc)
+    h  = Δz(surface_states)
     thermo_params = SFP.thermodynamics_params(param_set)
     g  = gravitational_acceleration
     𝒬ₒ = surface_state.ts # thermodynamic state
@@ -503,10 +513,13 @@ return
     uft = SFP.universal_func_type(param_set)
     # TODO: Rename HeatTransport -> ScalarTransport
     # ζ definition at this point? 
-    ψu = compute_Fₘₕ(sc, ufₛ, ζ, UF.MomentumTransport())
-    ψθ = compute_Fₘₕ(sc, ufₛ, ζ, UF.HeatTransport())
-    ψq = compute_Fₘₕ(sc, ufₛ, ζ, UF.HeatTransport())
-    b★ = compute_bstar(param_set, z/ζ, sc, uft, scheme)
+    ζ = eltype(uτ)(1)
+    ufₛ = UF.universal_func(uft, Δz(surface_states) / ζ, SFP.uf_params(param_set))
+    ψu = compute_Fₘₕ(surface_states, ufₛ, ζ, UF.MomentumTransport())
+    ψθ = compute_Fₘₕ(surface_states, ufₛ, ζ, UF.HeatTransport())
+    ψq = compute_Fₘₕ(surface_states, ufₛ, ζ, UF.HeatTransport())
+    scheme = PointValueScheme()
+    b★ = compute_bstar(param_set, Δz(surface_states)/ζ, surface_states, uft, scheme)
 
     # Monin-Obhukov characteristic length scale and non-dimensional height
     ϰ  = von_karman_constant
@@ -514,29 +527,30 @@ return
     
     #TODO: Compute roughness length scales
     #As a first example, assume that roughness length is constant
-    ℓu₀ = FT(1e-4)
-    ℓq₀ = FT(1e-3)
-    ℓθ₀ = FT(1e-3)
+    ℓu₀ = eltype(uτ)(1e-4)
+    ℓq₀ = eltype(uτ)(1e-3)
+    ℓθ₀ = eltype(uτ)(1e-3)
 
     # Transfer coefficients at height `h`
-    profile_type = similarity_theory.similarity_profile_type
+#    profile_type = similarity_theory.similarity_profile_type
 #    χu = ϰ / similarity_profile(profile_type, ψu, Δz, ℓu₀, L★)
 #    χθ = ϰ / similarity_profile(profile_type, ψθ, Δz, ℓθ₀, L★)
 #    χq = ϰ / similarity_profile(profile_type, ψq, Δz, ℓq₀, L★)
 
-    χu = compute_physical_scale_coeff(param_set, sc, Δz/ζ, UF.MomentumTransport(), uft, scheme)
-    χθ = compute_physical_scale_coeff(param_set, sc, Δz/ζ, UF.HeatTransport(), uft, scheme)
-    χq = compute_physical_scale_coeff(param_set, sc, Δz/ζ, UF.HeatTransport(), uft, scheme)
+    dz = Δz(surface_states)
+    χu = compute_physical_scale_coeff(param_set, surface_states, dz/ζ, UF.MomentumTransport(), uft, scheme)
+    χθ = compute_physical_scale_coeff(param_set, surface_states, dz/ζ, UF.HeatTransport(), uft, scheme)
+    χq = compute_physical_scale_coeff(param_set, surface_states, dz/ζ, UF.HeatTransport(), uft, scheme)
 
-    Δu = Δu1(sc)
-    Δv = Δu2(sc)
-    Δθ = Δθ(sc)
-    Δq = Δqt(sc)
+    δu = Δu1(surface_states)
+    δv = Δu2(surface_states)
+    δθ = Δθ(param_set, surface_states)
+    δq = Δqt(param_set, surface_states)
 
     # u★ including gustiness
     u★ = χu * uτ
-    θ★ = χθ * Δθ
-    q★ = χq * Δq
+    θ★ = χθ * δθ
+    q★ = χq * δq
 
     # Buoyancy flux characteristic scale for gustiness (Edson 2013)
     hᵢ = atmos_boundary_layer_height
@@ -544,68 +558,82 @@ return
     Uᴳ = β * cbrt(Jᵇ * hᵢ)
 
     # New velocity difference accounting for gustiness
-    ΔU = sqrt(Δu^2 + Δv^2 + Uᴳ^2)
+    ΔU = sqrt(δu^2 + δv^2 + Uᴳ^2)
 
     #return SimilarityScales(u★, θ★, q★), ΔU
-    return (u★, θ★, q★, ΔU)
+    return ((u★, θ★, q★), ΔU)
 end
 
-function iterating(Σ★, iteration, maxiter, solver)
-    havent_started = iteration == 0
-    not_converged = norm(Σ★) > solver.tolerance
-    havent_reached_maxiter = iteration < maxiter
-    return havent_started | not_converged | havent_reached_maxiter
+
+function iterating(Σ★, iteration, maxiter)
+#    havent_started = iteration == 0
+#    not_converged = norm(Σ★) > sqrt(eps(eltype(Σ★)))
+#    havent_reached_maxiter = iteration < maxiter
+#    return havent_started | not_converged | havent_reached_maxiter
+    if iteration < maxiter
+        return true
+    else
+        return false
+    end
 end
 
-function compute_monin_obukhov_fluxes(surface_state,
-                                      atmos_state, 
+function compute_monin_obukhov_fluxes(surface_states,
                                       atmos_boundary_layer_height,
                                       param_set)
+
+    surface_state = surface_states.state_sfc
+    atmos_state = surface_states.state_in
+
+    δu = Δu1(surface_states)
+    δv = Δu2(surface_states)
+    δz = Δz(surface_states)
+    δθ = Δθ(param_set, surface_states)
+    δq = Δqt(param_set, surface_states)
+
     gravitational_acceleration = SFP.grav(param_set)
     FT = eltype(gravitational_acceleration)
-    von_karman_constant = SFP.von_karman_constant(param_set)
+    von_karman_constant = SFP.von_karman_const(param_set)
     thermo_params = SFP.thermodynamics_params(param_set)
-
+    velocity_scale = δu 
+    
     u★ = convert(eltype(Δz), 1e-4)
     Σ★ = (u★, u★, u★)
     Uᴳᵢ² = convert(FT, 0.5^2)
-    ΔU = sqrt(Δu^2 + Δv^2 + Uᴳᵢ²)
+    ΔU = sqrt(δu^2 + δv^2 + Uᴳᵢ²)
 
     # Initialize the solver
     iteration = 0
     Σ₀ = Σ★
-
-    while iterating(Σ★ - Σ₀, iteration, maxiter, similarity_theory)
-        Σ₀ = Σ★
+    maxiter = 10
+    while iterating(Σ★ .- Σ₀, iteration, maxiter)
         # Refine both the characteristic scale and the effective
         # velocity difference ΔU, including gustiness.
-        Σ★, ΔU = refine_similarity_variables(Σ★, ΔU, 
-                                             similarity_theory,
-                                             surface_state,
-                                             differences,
+        Σ★, ΔU = refine_similarity_variables(Σ★,
+                                             velocity_scale, 
+                                             surface_states,
                                              atmos_boundary_layer_height,
-                                             thermodynamics_parameters,
-                                             gravitational_acceleration,
-                                             von_karman_constant)
+                                             thermo_params,
+                                             param_set)
         iteration += 1
     end
 
-    u★ = Σ★.momentum
-    θ★ = Σ★.temperature
-    q★ = Σ★.water_vapor
+    u★ = Σ★[1]
+    θ★ = Σ★[2]
+    q★ = Σ★[3]
 
-    θ★ = θ★ / similarity_theory.turbulent_prandtl_number
-    q★ = q★ / similarity_theory.turbulent_prandtl_number
+    turbulent_prandtl_number = FT(1/3)
+    θ★ = θ★ / turbulent_prandtl_number
+    q★ = q★ / turbulent_prandtl_number
 
     # `u★² ≡ sqrt(τx² + τy²)`
     # We remove the gustiness by dividing by `ΔU`
-    τx = - u★^2 * Δu / ΔU
-    τy = - u★^2 * Δv / ΔU
+    τx = - u★^2 * Δu1(surface_states) / ΔU
+    τy = - u★^2 * Δu2(surface_states) / ΔU
 
     𝒬ₐ = atmos_state.ts
-    ρₐ = AtmosphericThermodynamics.air_density(ℂₐ, 𝒬ₐ)
-    cₚ = AtmosphericThermodynamics.cp_m(ℂₐ, 𝒬ₐ) # moist heat capacity
-    ℰv = AtmosphericThermodynamics.latent_heat_vapor(ℂₐ, 𝒬ₐ)
+    ρₐ = TD.air_density(thermo_params, 𝒬ₐ)
+    cₚ = TD.cp_m(thermo_params, 𝒬ₐ) # moist heat capacity
+    ℰv = TD.latent_heat_vapor(thermo_params, 𝒬ₐ)
 
     fluxes = (;
         sensible_heat = - ρₐ * cₚ * u★ * θ★,
@@ -614,9 +642,7 @@ function compute_monin_obukhov_fluxes(surface_state,
         x_momentum    = + ρₐ * τx,
         y_momentum    = + ρₐ * τy,
     )
-
     return fluxes
-
 end
 
 function obukhov_length(param_set, sc::FluxesAndFrictionVelocity, uft::UF.AUFT, scheme, args...)

--- a/src/similarity_theory.jl
+++ b/src/similarity_theory.jl
@@ -1,0 +1,211 @@
+### REVAMP 
+
+struct SimilarityScales{U, T, Q}
+    momentum :: U
+    temperature :: T
+    water_vapor :: Q
+end
+
+function -(a::SimilarityScales, b::SimilarityScales)
+    Δu = a.momentum - b.momentum
+    Δθ = a.temperature - b.temperature
+    Δq = a.water_vapor - b.water_vapor
+    return SimilarityScales(Δu, Δθ, Δq)
+end
+
+struct SurfaceState{RL, 
+                    U <: Union{Function, FT}, V <: Union{Function, FT}, 
+                    Q <: Union{Function, FT}, T <: Union{Function, FT}, 
+                    X, FT} <: AbstractStateVariables{FT <: AbstractFloat} 
+    roughness_lengths::RL # Should be a named tuple with vapor, momentum, and buoyancy. Those should then be of type Union{Function, FT}
+    u_s::U
+    v_s::V
+    h::FT
+    q_s::Q
+    θ_s::T
+    args::X
+    gustiness::FT
+end
+
+"""
+    state_differences(surface_state, atmos_state, similarity_scales, params)
+returns `NamedTuple` of state differences across first interior cell
+"""
+function state_differences(surface_state, atmos_state, similarity_scales, params)
+    q_a = atmos_state.q_a
+    surface_args = surface_state.args
+    q_s = surface_state.q_s(surface_args, similarity_scales, atmos_state, params)
+    Δq = q_a - q_s
+    
+    u_a = atmos_state.u_a
+    u_s = surface_state.u_s(surface_args, similarity_scales, atmos_state, params)
+    Δu = u_a - u_s
+    
+    v_a = atmos_state.v_a
+    v_s = surface_state.v_s(surface_args, similarity_scales, atmos_state, params)
+    Δv = v_a - v_s
+    
+    θ_a = atmos_state.θ_a
+    θ_s = surface_state.θ_s(surface_args, similarity_scales, atmos_state, params)
+    Δθ= θ_a - θ_s
+    
+    h_a = atmos_state.h_a
+    h_s = surface_state.h_s
+    Δh = h_a - h_s 
+
+    return (; Δu=Δu, Δv=Δv, Δθ=Δθ, Δq=Δq, Δh=Δh)
+end
+
+Statistics.norm(a::SimilarityScales) = norm(a.momentum) + norm(a.temperature) + norm(a.water_vapor)
+
+#####
+##### Fixed-point iteration for roughness length
+#####
+
+@inline function compute_similarity_theory_fluxes(similarity_theory,
+                                                  surface_state,
+                                                  atmos_state,
+                                                  params,
+                                                  maxiter)
+        
+    # TODO: Unpack params for 𝜅, grav, thermo_params, h_atmos_boundary_layer
+
+    # Prescribed difference between two states
+    ℂₐ = thermodynamics_parameters
+
+    # Initial guess for the similarity scales u★, θ★, q★.
+    # Does not really matter if we are sophisticated or not, it converges 
+    # in about 10 iterations no matter what...
+    u★ = convert(eltype(Δh), 1e-4)
+    Σ★ = SimilarityScales(u★, u★, u★) 
+
+    Δstate = state_differences(surface_state, atmos_state, Σ★, params)
+
+    # The inital velocity scale assumes that
+    # the gustiness velocity `Uᴳ` is equal to 0.5 ms⁻¹. 
+    # That will be refined later on.
+    FT = eltype(Δstate.Δh)
+    Uᴳᵢ² = convert(FT, 0.5^2)
+    ΔU = sqrt(Δstate.Δu^2 + Δstate.Δv^2 + Uᴳᵢ²)
+
+    # Initialize the solver
+    iteration = 0
+    Σ₀ = Σ★
+    while iterating(Σ★ - Σ₀, iteration, maxiter, similarity_theory)
+        Σ₀ = Σ★
+        # Refine both the similarity scale and the effective
+        # velocity difference ΔU, including gustiness.
+        Σ★, ΔU = refine_similarity_variables(Σ★, 
+                                             ΔU, 
+                                             similarity_theory,
+                                             surface_state,
+                                             atmos_state,
+                                             params) 
+        # params contains 
+        #       thermo_params
+        #       atmos boundary layer height
+        #       von karman constant
+        #       gravitational acceleration
+        iteration += 1
+    end
+
+    u★ = Σ★.momentum
+    θ★ = Σ★.temperature
+    q★ = Σ★.water_vapor
+
+    θ★ = θ★ / similarity_theory.turbulent_prandtl_number
+    q★ = q★ / similarity_theory.turbulent_prandtl_number
+
+    # `u★² ≡ sqrt(τx² + τy²)`
+    # We remove the gustiness by dividing by `ΔU`
+    τx = - u★^2 * Δu / ΔU
+    τy = - u★^2 * Δv / ΔU
+
+    𝒬ₐ = atmos_state.ts
+    ρₐ = AtmosphericThermodynamics.air_density(ℂₐ, 𝒬ₐ)
+    cₚ = AtmosphericThermodynamics.cp_m(ℂₐ, 𝒬ₐ) # moist heat capacity
+    ℰv = AtmosphericThermodynamics.latent_heat_vapor(ℂₐ, 𝒬ₐ)
+
+    fluxes = (;
+        sensible_heat = - ρₐ * cₚ * u★ * θ★,
+        latent_heat   = - ρₐ * u★ * q★ * ℰv,
+        water_vapor   = - ρₐ * u★ * q★,
+        x_momentum    = + ρₐ * τx,
+        y_momentum    = + ρₐ * τy,
+    )
+
+    return fluxes
+end
+
+"""
+    TODO: Refactor OCEAN model expressions to match `SurfaceStates` 
+"""
+@inline function refine_similarity_variables(estimated_similarity_scales, 
+                                             velocity_scale,
+                                             similarity_theory,
+                                             surface_state,
+                                             atmos_state,
+                                             params)
+    # TODO Check param unpack
+    
+    Δstate = state_differences(surface_state, atmos_state, estimated_similarity_scales, params)
+    h  = Δstate.Δh
+    (z0m, z0θ, z0b) = surface_state.roughness_lengths
+    
+    ζ = # Given u★ = u★²/𝜅b★ # Check signs
+    
+    z₀b = surface_state.roughness_lengths.z₀b(surface_args, similarity_scales, atmos_state, params)
+    z₀u = surface_state.roughness_lengths.z₀u(surface_args, similarity_scales, atmos_state, params)
+
+    # Current SurfaceFluxes calls to stability functions 
+    ψₘ = UF.psi(similarity_theory, ζ, UF.MomentumTransport())
+    ψₕ = UF.psi(similarity_theory, ζ, UF.ScalarTransport())
+    ψₘ₀ = UF.psi(similarity_theory, z₀u * ζ / h, UF.MomentumTransport())
+    ψₕ₀ = UF.psi(similarity_theory, z₀b * ζ / h, UF.ScalarTransport())
+    
+    denominator = log(Δh / z0(sc, transport)) - ψ + ψ₀
+
+    # "initial" scales because we will recompute them
+    u★ = estimated_similarity_scales.momentum
+    θ★ = estimated_similarity_scales.temperature
+    q★ = estimated_similarity_scales.water_vapor
+    uτ = velocity_scale
+
+    # Extract roughness lengths
+    gustiness = surface_states.gustiness_parameter 
+    thermo_params  = thermodynamics_parameters
+    g  = gravitational_acceleration
+
+    # Compute Monin-Obukhov length scale depending on a `buoyancy flux`
+    # TODO: Check buoyancy_scale function definitions and conventions
+    b★ = buoyancy_scale(θ★, q★, thermo_params)
+    # Monin-Obhukov similarity length scale and non-dimensional height
+    ϰ  = von_karman_constant
+    L★ = ifelse(b★ == 0, zero(b★), - u★^2 / (ϰ * b★))
+    
+    # Transfer coefficients at height `h`
+    profile_type = similarity_theory.similarity_profile_type
+    χu = ϰ /denom
+    χθ = ϰ /denom
+    χq = ϰ /denom
+
+    Δu = differences.u
+    Δv = differences.v
+    Δθ = differences.θ
+    Δq = differences.q
+
+    # u★ including gustiness
+    u★ = χu * uτ
+    θ★ = χθ * Δθ
+    q★ = χq * Δq
+
+    # Buoyancy flux similarity scale for gustiness (Edson 2013)
+    hᵢ = atmos_boundary_layer_height
+    Jᵇ = - u★ * b★
+    Uᴳ = gustiness * cbrt(Jᵇ * hᵢ)
+
+    # New velocity difference accounting for gustiness
+    ΔU = sqrt(Δu^2 + Δv^2 + Uᴳ^2)
+
+    return SimilarityScales(u★, θ★, q★), ΔU
+end

--- a/src/similarity_theory.jl
+++ b/src/similarity_theory.jl
@@ -241,12 +241,15 @@ end
     (; Δu, Δv, Δθ, Δq, Δh) = state_differences(surface_state, atmos_state, Σ_est, params)
 
     # Unpack and compute roughness lengths according to the surface model functions
-    (; 𝑧0m, 𝑧0θ, 𝑧0q) = surface_state.roughness_lengths
-
-    # ??
-    #z₀q = surface_variable(roughness_length_q,surface_args,similarity_scales,atmos_state,params)
-    #z₀b = surface_variable(roughness_length_θ,surface_args,similarity_scales,atmos_state,params)
-    #z₀u = surface_variable(roughness_length_mom,surface_args,similarity_scales,atmos_state,params)
+    𝑧0m =surface_variable(surface_state.roughness_lengths.𝑧0m, 
+                         surface_args, 
+                          Σ_est, atmos_state, params)
+    𝑧0θ =surface_variable(surface_state.roughness_lengths.𝑧0θ, 
+                          surface_args, 
+                          Σ_est, atmos_state, params)
+    𝑧0q =surface_variable(surface_state.roughness_lengths.𝑧0q, 
+                          surface_args, 
+                          Σ_est, atmos_state, params)
 
     # "initial" scales because we will recompute them
     u★ = Σ_est.momentum
@@ -264,14 +267,14 @@ end
 
     ψm = UF.psi(ufunc, ζ, UF.MomentumTransport())
     ψs = UF.psi(ufunc, ζ, UF.HeatTransport()) # TODO Rename HeatTransport > ScalarTransport
-    ψm₀ = UF.psi(ufunc, 𝑧0m * ζ / Δstate.Δh, UF.MomentumTransport())
-    ψh₀ = UF.psi(ufunc, 𝑧0θ * ζ / Δstate.Δh, UF.HeatTransport())
-    ψq₀ = UF.psi(ufunc, 𝑧0q(u★,ζ) * ζ / Δstate.Δh, UF.HeatTransport())
+    ψm₀ = UF.psi(ufunc, 𝑧0m * ζ / Δh, UF.MomentumTransport())
+    ψh₀ = UF.psi(ufunc, 𝑧0θ * ζ / Δh, UF.HeatTransport())
+    ψq₀ = UF.psi(ufunc, 𝑧0q * ζ / Δh, UF.HeatTransport())
  
     # compute rhs in Δχ/u★ = (f(ζ,𝑧0...))
-    F_m = log(Δstate.Δh / 𝑧0m) - ψm + ψm₀
-    F_h = log(Δstate.Δh / 𝑧0θ) - ψs + ψh₀
-    F_q = log(Δstate.Δh / 𝑧0q(u★, ζ)) - ψs + ψq₀
+    F_m = log(Δh / 𝑧0m) - ψm + ψm₀
+    F_h = log(Δh / 𝑧0θ) - ψs + ψh₀
+    F_q = log(Δh / 𝑧0q) - ψs + ψq₀
 
     # Review against nishizawa notation
     χu = 𝜅/F_m 
@@ -279,8 +282,8 @@ end
     χq = 𝜅/F_m
 
     u★ = χu * uτ
-    θ★ = χθ * Δstate.Δθ
-    q★ = χq * Δstate.Δq
+    θ★ = χθ * Δθ
+    q★ = χq * Δq
     
     # Buoyancy flux similarity scale for gustiness (Edson 2013)
     hᵢ = h_atmos_boundary_layer

--- a/src/similarity_theory.jl
+++ b/src/similarity_theory.jl
@@ -1,52 +1,82 @@
 ### REVAMP 
 
+"""
+    SimilarityScales
+
+Holds the Monin-Obukhov solution state u★, θ★, q★
+"""
 struct SimilarityScales{U, T, Q}
-    momentum :: U
-    temperature :: T
-    water_vapor :: Q
+    momentum::U # ustar
+    temperature::T # bstar or theta-star?
+    water_vapor::Q # qstar
 end
 
+"""
+    -(a::SimilarityScales, b::SimilarityScales)
+
+Component-wise subtraction
+"""
 function -(a::SimilarityScales, b::SimilarityScales)
     Δu = a.momentum - b.momentum
-    Δθ = a.temperature - b.temperature
+    Δb = a.temperature - b.temperature
     Δq = a.water_vapor - b.water_vapor
     return SimilarityScales(Δu, Δθ, Δq)
 end
 
+Statistics.norm(a::SimilarityScales) = norm(a.momentum) + norm(a.temperature) + norm(a.water_vapor)
+
+"""
+    SurfaceStates
+
+Holds the functions required to compute roughness lengths, surface conditions
+"""
 struct SurfaceState{RL, 
-                    U <: Union{Function, FT}, V <: Union{Function, FT}, 
-                    Q <: Union{Function, FT}, T <: Union{Function, FT}, 
-                    X, FT} <: AbstractStateVariables{FT <: AbstractFloat} 
+                    U <: Union{Function, FT},
+                    V <: Union{Function, FT}, 
+                    Q <: Union{Function, FT},
+                    T <: Union{Function, FT}, 
+                    X,
+                    FT} <: AbstractStateVariables where {FT <: AbstractFloat} 
     roughness_lengths::RL # Should be a named tuple with vapor, momentum, and buoyancy. Those should then be of type Union{Function, FT}
     u_s::U
     v_s::V
-    h::FT
     q_s::Q
     θ_s::T
-    args::X
+    args::X # whatever is needed to compute surface conditions, provided by the surface model.
+    h::FT
     gustiness::FT
 end
 
+function surface_variable(surface_state_var::Function, surface_args, similarity_scales, atmos_state, params)
+    return surface_state_var(surface_args, similarity_scales, atmos_state, params)
+end
+
+function surface_variable(surface_state_var::FT, _...) where {FT <: AbstractFloat}
+    return surface_state_var
+end
+    
 """
     state_differences(surface_state, atmos_state, similarity_scales, params)
+
 returns `NamedTuple` of state differences across first interior cell
 """
 function state_differences(surface_state, atmos_state, similarity_scales, params)
-    q_a = atmos_state.q_a
     surface_args = surface_state.args
-    q_s = surface_state.q_s(surface_args, similarity_scales, atmos_state, params)
+    
+    q_a = atmos_state.q_a
+    q_s = surface_variable(surface_state.q_s, surface_args, similarity_scales, atmos_state, params)
     Δq = q_a - q_s
     
     u_a = atmos_state.u_a
-    u_s = surface_state.u_s(surface_args, similarity_scales, atmos_state, params)
+    u_s = surface_variable(surface_state.u_s, surface_args, similarity_scales, atmos_state, params)
     Δu = u_a - u_s
     
     v_a = atmos_state.v_a
-    v_s = surface_state.v_s(surface_args, similarity_scales, atmos_state, params)
+    v_s = surface_variable(surface_state.v_s, surface_args, similarity_scales, atmos_state, params)
     Δv = v_a - v_s
     
     θ_a = atmos_state.θ_a
-    θ_s = surface_state.θ_s(surface_args, similarity_scales, atmos_state, params)
+    θ_s = surface_variable(surface_state.θ_s, surface_args, similarity_scales, atmos_state, params)
     Δθ= θ_a - θ_s
     
     h_a = atmos_state.h_a
@@ -56,7 +86,7 @@ function state_differences(surface_state, atmos_state, similarity_scales, params
     return (; Δu=Δu, Δv=Δv, Δθ=Δθ, Δq=Δq, Δh=Δh)
 end
 
-Statistics.norm(a::SimilarityScales) = norm(a.momentum) + norm(a.temperature) + norm(a.water_vapor)
+
 
 #####
 ##### Fixed-point iteration for roughness length
@@ -69,24 +99,21 @@ Statistics.norm(a::SimilarityScales) = norm(a.momentum) + norm(a.temperature) + 
                                                   maxiter)
         
     # TODO: Unpack params for 𝜅, grav, thermo_params, h_atmos_boundary_layer
-
-    # Prescribed difference between two states
-    ℂₐ = thermodynamics_parameters
-
+    (; grav, thermo_params, 𝜅, h_atmos_boundary_layer) = params
+    FT = typeof(grav)
     # Initial guess for the similarity scales u★, θ★, q★.
     # Does not really matter if we are sophisticated or not, it converges 
     # in about 10 iterations no matter what...
-    u★ = convert(eltype(Δh), 1e-4)
+    u★ = FT(1e-4)
     Σ★ = SimilarityScales(u★, u★, u★) 
 
-    Δstate = state_differences(surface_state, atmos_state, Σ★, params)
+    (; Δu, Δv, Δθ, Δq, Δh) = state_differences(surface_state, atmos_state, Σ★, params)
 
     # The inital velocity scale assumes that
     # the gustiness velocity `Uᴳ` is equal to 0.5 ms⁻¹. 
     # That will be refined later on.
-    FT = eltype(Δstate.Δh)
     Uᴳᵢ² = convert(FT, 0.5^2)
-    ΔU = sqrt(Δstate.Δu^2 + Δstate.Δv^2 + Uᴳᵢ²)
+    ΔU = sqrt(Δu^2 + Δv^2 + Uᴳᵢ²)
 
     # Initialize the solver
     iteration = 0
@@ -113,25 +140,31 @@ Statistics.norm(a::SimilarityScales) = norm(a.momentum) + norm(a.temperature) + 
     θ★ = Σ★.temperature
     q★ = Σ★.water_vapor
 
+    # Compute updated state differences
+    (; Δu, Δv, Δθ, Δq, Δh) = state_differences(surface_state, atmos_state, Σ★, params)
+
     θ★ = θ★ / similarity_theory.turbulent_prandtl_number
     q★ = q★ / similarity_theory.turbulent_prandtl_number
-
+    
     # `u★² ≡ sqrt(τx² + τy²)`
     # We remove the gustiness by dividing by `ΔU`
     τx = - u★^2 * Δu / ΔU
     τy = - u★^2 * Δv / ΔU
 
-    𝒬ₐ = atmos_state.ts
-    ρₐ = AtmosphericThermodynamics.air_density(ℂₐ, 𝒬ₐ)
-    cₚ = AtmosphericThermodynamics.cp_m(ℂₐ, 𝒬ₐ) # moist heat capacity
-    ℰv = AtmosphericThermodynamics.latent_heat_vapor(ℂₐ, 𝒬ₐ)
+    atmos_ts = atmos_state.ts
+    ρ_a= AtmosphericThermodynamics.air_density(thermo_params, atmos_ts)
+    cp_m = AtmosphericThermodynamics.cp_m(thermo_params, atmos_ts) # moist heat capacity
+    LH_v= AtmosphericThermodynamics.latent_heat_vapor(thermo_params, atmos_ts)
 
+    # These currently are not consistent with the dycore paper
+    # Use ρ_s, use ΔDSE (use LH_v0?)
     fluxes = (;
-        sensible_heat = - ρₐ * cₚ * u★ * θ★,
-        latent_heat   = - ρₐ * u★ * q★ * ℰv,
-        water_vapor   = - ρₐ * u★ * q★,
-        x_momentum    = + ρₐ * τx,
-        y_momentum    = + ρₐ * τy,
+              sensible_heat = - ρ_a * cp_m * u★ * θ★,
+              latent_heat   = - ρ_a * u★ * q★ * LH_v,
+              water_vapor   = - ρ_a * u★ * q★,
+              x_momentum    = + ρ_a * τx,
+              y_momentum    = + ρ_a * τy,
+              r_ae = Δq/(ρ_a * u★ * q★) # Land needs this, and it is not computable internally to land from only the fluxes in coupled simulation.
     )
 
     return fluxes
@@ -140,59 +173,52 @@ end
 """
     TODO: Refactor OCEAN model expressions to match `SurfaceStates` 
 """
-@inline function refine_similarity_variables(estimated_similarity_scales, 
-                                             velocity_scale,
+@inline function refine_similarity_variables(Σ_est, 
+                                             ΔU_est,
                                              similarity_theory,
                                              surface_state,
                                              atmos_state,
                                              params)
-    # TODO Check param unpack
-    
-    Δstate = state_differences(surface_state, atmos_state, estimated_similarity_scales, params)
-    h  = Δstate.Δh
-    (z0m, z0θ, z0b) = surface_state.roughness_lengths
-    
-    ζ = # Given u★ = u★²/𝜅b★ # Check signs
-    
-    z₀b = surface_state.roughness_lengths.z₀b(surface_args, similarity_scales, atmos_state, params)
-    z₀u = surface_state.roughness_lengths.z₀u(surface_args, similarity_scales, atmos_state, params)
 
-    # Current SurfaceFluxes calls to stability functions 
-    ψₘ = UF.psi(similarity_theory, ζ, UF.MomentumTransport())
-    ψₕ = UF.psi(similarity_theory, ζ, UF.ScalarTransport())
-    ψₘ₀ = UF.psi(similarity_theory, z₀u * ζ / h, UF.MomentumTransport())
-    ψₕ₀ = UF.psi(similarity_theory, z₀b * ζ / h, UF.ScalarTransport())
+    (; grav, thermo_params, 𝜅, h_atmos_boundary_layer) = params
+    gustiness = surface_states.gustiness_parameter
     
-    denominator = log(Δh / z0(sc, transport)) - ψ + ψ₀
+    # Update the state differences given the new guess for Σ
+    (; Δu, Δv, Δθ, Δq, Δh) = state_differences(surface_state, atmos_state, Σ_est, params)
+
+    # Unpack and compute roughness lengths according to the surface model functions
+    (; roughness_length_mom, roughness_length_θ, roughness_length_q) = surface_state.roughness_lengths
+
+    z₀q = surface_variable(roughness_length_q, surface_args, similarity_scales, atmos_state, params)
+    z₀b = surface_variable(roughness_length_θ, surface_args, similarity_scales, atmos_state, params)
+    z₀u = surface_variable(roughness_length_mom, surface_args, similarity_scales, atmos_state, params)
 
     # "initial" scales because we will recompute them
-    u★ = estimated_similarity_scales.momentum
-    θ★ = estimated_similarity_scales.temperature
-    q★ = estimated_similarity_scales.water_vapor
-    uτ = velocity_scale
-
-    # Extract roughness lengths
-    gustiness = surface_states.gustiness_parameter 
-    thermo_params  = thermodynamics_parameters
-    g  = gravitational_acceleration
+    u★ = Σ_est.momentum
+    θ★ = Σ_est.temperature
+    q★ = Σ_est.water_vapor
+    uτ = ΔU_est
 
     # Compute Monin-Obukhov length scale depending on a `buoyancy flux`
     # TODO: Check buoyancy_scale function definitions and conventions
     b★ = buoyancy_scale(θ★, q★, thermo_params)
     # Monin-Obhukov similarity length scale and non-dimensional height
-    ϰ  = von_karman_constant
     L★ = ifelse(b★ == 0, zero(b★), - u★^2 / (ϰ * b★))
+
+    # Current SurfaceFluxes calls to stability functions 
     
+    ζ = # Given u★, L = u★²/𝜅b★ # Check signs
+    ψₘ = UF.psi(similarity_theory, ζ, UF.MomentumTransport())
+    ψₕ = UF.psi(similarity_theory, ζ, UF.ScalarTransport())
+    ψₘ₀ = UF.psi(similarity_theory, z₀u * ζ / h, UF.MomentumTransport())
+    ψₕ₀ = UF.psi(similarity_theory, z₀b * ζ / h, UF.ScalarTransport())
+    
+    denom = log(Δh / z0(sc, transport)) - ψ + ψ₀
+
     # Transfer coefficients at height `h`
-    profile_type = similarity_theory.similarity_profile_type
     χu = ϰ /denom
     χθ = ϰ /denom
     χq = ϰ /denom
-
-    Δu = differences.u
-    Δv = differences.v
-    Δθ = differences.θ
-    Δq = differences.q
 
     # u★ including gustiness
     u★ = χu * uτ
@@ -200,7 +226,7 @@ end
     q★ = χq * Δq
 
     # Buoyancy flux similarity scale for gustiness (Edson 2013)
-    hᵢ = atmos_boundary_layer_height
+    hᵢ = h_atmos_boundary_layer
     Jᵇ = - u★ * b★
     Uᴳ = gustiness * cbrt(Jᵇ * hᵢ)
 

--- a/src/similarity_theory.jl
+++ b/src/similarity_theory.jl
@@ -203,7 +203,8 @@ end
               water_vapor   = - ρ_s * u★ * q★, # This might be OK
               x_momentum    = + ρ_s * τx,
               y_momentum    = + ρ_s * τy,
-              r_ae = Δq/(ρ_a * u★ * q★) # Land needs this, and it is not computable internally to land from only the fluxes in coupled simulation.
+              r_ae = Δq/(ρ_a * u★ * q★), # Land needs this, and it is not computable internally to land from only the fluxes in coupled simulation.
+              scale_vars = (u★, θ★, q★),
     )
 
     return fluxes

--- a/test/new_formulation.jl
+++ b/test/new_formulation.jl
@@ -46,10 +46,6 @@ surface_state = SurfaceState(
                   (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
                 )
 
-compute_similarity_theory_fluxes(similarity_profile, 
-                                 surface_state,
-                                 atmos_state, 
-                                 param_set; maxiter = 10)
 
 # Test function inputs within `args` : see ClimaOcean for uniformity 
 # in unpack methods.
@@ -109,16 +105,21 @@ u★ = χu * uτ
 q★ = χq * Δstate.Δq
 
 # Buoyancy flux similarity scale for gustiness (Edson 2013)
+h_atmos_boundary_layer = FT(100)
 hᵢ = h_atmos_boundary_layer
 Jᵇ = - u★ * b★
 Uᴳ = gustiness * cbrt(Jᵇ * hᵢ)
 
 # New velocity difference accounting for gustiness
-ΔU = sqrt(Δu^2 + Δv^2 + Uᴳ^2)
+ΔU = sqrt(Δstate.Δu^2 + Δstate.Δv^2 + Uᴳ^2)
 
 # TODO: z0test to be redefined with `surface_args`, `similarity_scales` as args
 
-#### With 
+similarity_profile = ufunc
+compute_similarity_theory_fluxes(similarity_profile, 
+                                 surface_state,
+                                 atmos_state, 
+                                 param_set)
 
 #### Diagnostics
 @info atmos_state.args

--- a/test/new_formulation.jl
+++ b/test/new_formulation.jl
@@ -23,7 +23,12 @@ thermo_params = param_set.thermo_params
 
 # Assign states
 
-z0test(u★, ζ) = FT(0.015 * u★^2 / 9.81)
+function z0test(surface_args, similarity_scales, atmos_state, param_set)
+    u★ = similarity_scales.momentum
+    FT =typeof(u★)
+    return FT(0.015 * u★^2 / 9.81)
+end
+
 
 atmos_state = AtmosState(
                   FT(5),
@@ -72,7 +77,7 @@ q★ = Σ_est.water_vapor
 uτ = ΔU_est
 
 similarity_profile = ufunc
-similarity_scales = refine_similarity_variables(Σ_est, ΔU, 
+similarity_scales = refine_similarity_variables(Σ_est, ΔU_est, 
                                      similarity_profile,
                                      surface_state, 
                                      atmos_state, param_set)

--- a/test/new_formulation.jl
+++ b/test/new_formulation.jl
@@ -70,45 +70,6 @@ u★ = Σ_est.momentum
 θ★ = Σ_est.temperature
 q★ = Σ_est.water_vapor
 uτ = ΔU_est
-## TODO Define methods for buoyancy_scale; current implementation uses `compute_bstar`
-#b★ = buoyancy_scale(θ★, q★, thermo_params)
-b★ = FT(0.2)
-
-## TODO Fix Parameter unpack methods (unify between ClimaOcean and ClimaParams)
-𝑔 = FT(9.81)
-𝜅 = FT(0.4)
-L★ = ifelse(b★ == 0, zero(b★), - u★^3 * atmos_state.θ_a / (u★ * θ★ * 𝜅 * 𝑔))
-ζ = Δstate.Δh / L★ 
-ψm = UF.psi(ufunc, ζ, UF.MomentumTransport())
-ψs = UF.psi(ufunc, ζ, UF.HeatTransport()) # TODO Rename HeatTransport > ScalarTransport
-ψm₀ = UF.psi(ufunc, 𝑧0m * ζ / Δstate.Δh, UF.MomentumTransport())
-ψh₀ = UF.psi(ufunc, 𝑧0θ * ζ / Δstate.Δh, UF.HeatTransport())
-ψq₀ = UF.psi(ufunc, 𝑧0q(u★,ζ) * ζ / Δstate.Δh, UF.HeatTransport())
-
-# compute rhs in Δχ/u★ = (f(ζ,𝑧0...))
-F_m = log(Δstate.Δh / 𝑧0m) - ψm + ψm₀
-F_h = log(Δstate.Δh / 𝑧0θ) - ψs + ψh₀
-F_q = log(Δstate.Δh / 𝑧0q(u★, ζ)) - ψs + ψq₀
-
-# Review against nishizawa notation
-χu = 𝜅/F_m 
-χθ = 𝜅/F_m
-χq = 𝜅/F_m
-
-u★ = χu * uτ
-θ★ = χθ * Δstate.Δθ
-q★ = χq * Δstate.Δq
-
-# Buoyancy flux similarity scale for gustiness (Edson 2013)
-h_atmos_boundary_layer = FT(100)
-hᵢ = h_atmos_boundary_layer
-Jᵇ = - u★ * b★
-Uᴳ = gustiness * cbrt(Jᵇ * hᵢ)
-
-# New velocity difference accounting for gustiness
-ΔU = sqrt(Δstate.Δu^2 + Δstate.Δv^2 + Uᴳ^2)
-
-# TODO: z0test to be redefined with `surface_args`, `similarity_scales` as args
 
 similarity_profile = ufunc
 similarity_scales = refine_similarity_variables(Σ_est, ΔU, 
@@ -122,11 +83,6 @@ fluxes = compute_similarity_theory_fluxes(similarity_profile,
                                  param_set)
 
 #### Diagnostics
-@info atmos_state.args
-@info Δstate
-@info propertynames(surface_state)
-@info propertynames(atmos_state)
-@info similarity_theory
 @info ufunc
 @info "With ufunc.L = $(ufunc.L) the Monin Obukhov length"
 @info fluxes

--- a/test/new_formulation.jl
+++ b/test/new_formulation.jl
@@ -1,0 +1,130 @@
+include("../src/similarity_theory.jl")
+
+using Test
+import Thermodynamics as TD
+import SurfaceFluxes as SF
+import SurfaceFluxes.Parameters as SFP
+import SurfaceFluxes.UniversalFunctions.BusingerParams
+import SurfaceFluxes.UniversalFunctions as UF
+import ClimaParams as CP
+
+# Assume constant values
+# For method tests define functions for roughness that return constant values
+
+
+FT = Float32 # TODO Check all floattypes
+Σ₀ = SimilarityScales{FT, FT, FT}(1e-4,1e-4,1e-4)
+Σₜ = SimilarityScales{FT, FT, FT}(1e-5,1e-5,1e-5)
+ΔΣ = Σₜ- Σ₀
+
+# Parameters (ClimaParams types)
+param_set = SFP.SurfaceFluxesParameters(FT, BusingerParams)
+thermo_params = param_set.thermo_params
+
+# Assign states
+
+z0test(u★, ζ) = FT(0.01)   
+
+atmos_state = AtmosState(
+                  FT(1),
+                  FT(1),
+                  FT(0.002),
+                  FT(298),
+                  FT(15),
+                  FT(1), # gustiness needs to be a function of u,v, ustar
+                  FT(100),
+                  (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
+                )
+
+surface_state = SurfaceState(
+                  (𝑧0m=FT(0.01), 𝑧0θ=FT(0.01), 𝑧0q=z0test),
+                  FT(0),
+                  FT(0),
+                  FT(0.002),
+                  FT(299),
+                  FT(0),
+                  (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
+                )
+
+compute_similarity_theory_fluxes(similarity_profile, 
+                                 surface_state,
+                                 atmos_state, 
+                                 param_set; maxiter = 10)
+
+# Test function inputs within `args` : see ClimaOcean for uniformity 
+# in unpack methods.
+@assert atmos_state.args.arg𝑐(1,2) == FT(0.01)
+
+
+# Line by line debug and test for `refine` function
+gustiness = atmos_state.gustiness_parameter
+Δstate = state_differences(surface_state, atmos_state, Σ₀, param_set); 
+(; 𝑧0m, 𝑧0θ, 𝑧0q) = surface_state.roughness_lengths
+
+# Generic info block 
+
+ζ₀ = FT(-10)
+L★ = Δstate.Δh ./ ζ₀
+sfc_params = SFP.uf_params(param_set)
+similarity_theory = SFP.universal_func_type(param_set)
+ufunc = UF.universal_func(similarity_theory, L★, sfc_params)
+# We shouldn't need both these! ζ and `BusingerParams` should be enough (at the user level)
+# to define all similarity functions 𝜓, 𝜙
+
+Σ_est = (momentum=FT(0.1),temperature=FT(0.01),water_vapor=FT(0.001))
+ΔU_est = FT(10)
+
+# Initial guess
+u★ = Σ_est.momentum
+θ★ = Σ_est.temperature
+q★ = Σ_est.water_vapor
+uτ = ΔU_est
+## TODO Define methods for buoyancy_scale; current implementation uses `compute_bstar`
+#b★ = buoyancy_scale(θ★, q★, thermo_params)
+b★ = FT(0.2)
+
+## TODO Fix Parameter unpack methods (unify between ClimaOcean and ClimaParams)
+𝑔 = FT(9.81)
+𝜅 = FT(0.4)
+L★ = ifelse(b★ == 0, zero(b★), - u★^3 * atmos_state.θ_a / (u★ * θ★ * 𝜅 * 𝑔))
+ζ = Δstate.Δh / L★ 
+ψm = UF.psi(ufunc, ζ, UF.MomentumTransport())
+ψs = UF.psi(ufunc, ζ, UF.HeatTransport()) # TODO Rename HeatTransport > ScalarTransport
+ψm₀ = UF.psi(ufunc, 𝑧0m * ζ / Δstate.Δh, UF.MomentumTransport())
+ψh₀ = UF.psi(ufunc, 𝑧0θ * ζ / Δstate.Δh, UF.HeatTransport())
+ψq₀ = UF.psi(ufunc, 𝑧0q(u★,ζ) * ζ / Δstate.Δh, UF.HeatTransport())
+
+# compute rhs in Δχ/u★ = (f(ζ,𝑧0...))
+F_m = log(Δstate.Δh / 𝑧0m) - ψm + ψm₀
+F_h = log(Δstate.Δh / 𝑧0θ) - ψs + ψh₀
+F_q = log(Δstate.Δh / 𝑧0q(u★, ζ)) - ψs + ψq₀
+
+# Review against nishizawa notation
+χu = 𝜅/F_m 
+χθ = 𝜅/F_m
+χq = 𝜅/F_m
+
+u★ = χu * uτ
+θ★ = χθ * Δstate.Δθ
+q★ = χq * Δstate.Δq
+
+# Buoyancy flux similarity scale for gustiness (Edson 2013)
+hᵢ = h_atmos_boundary_layer
+Jᵇ = - u★ * b★
+Uᴳ = gustiness * cbrt(Jᵇ * hᵢ)
+
+# New velocity difference accounting for gustiness
+ΔU = sqrt(Δu^2 + Δv^2 + Uᴳ^2)
+
+# TODO: z0test to be redefined with `surface_args`, `similarity_scales` as args
+
+#### With 
+
+#### Diagnostics
+@info atmos_state.args
+@info Δstate
+@info propertynames(surface_state)
+@info propertynames(atmos_state)
+@info similarity_theory
+@info ufunc
+@info "With ufunc.L = $(ufunc.L) the Monin Obukhov length"

--- a/test/new_formulation.jl
+++ b/test/new_formulation.jl
@@ -23,33 +23,28 @@ thermo_params = param_set.thermo_params
 
 # Assign states
 
-z0test(u★, ζ) = FT(0.01)   
+z0test(u★, ζ) = FT(0.015 * u★^2 / 9.81)
 
 atmos_state = AtmosState(
-                  FT(1),
+                  FT(5),
                   FT(1),
                   FT(0.002),
                   FT(298),
                   FT(15),
                   FT(1), # gustiness needs to be a function of u,v, ustar
                   FT(100),
-                  (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
+                  (ρ=FT(1.20), arg𝑏=FT(0.01), arg𝑐=z0test),
                 )
 
 surface_state = SurfaceState(
                   (𝑧0m=FT(0.01), 𝑧0θ=FT(0.01), 𝑧0q=z0test),
                   FT(0),
                   FT(0),
-                  FT(0.002),
-                  FT(299),
+                  FT(0.003),
+                  FT(304),
                   FT(0),
                   (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
                 )
-
-
-# Test function inputs within `args` : see ClimaOcean for uniformity 
-# in unpack methods.
-@assert atmos_state.args.arg𝑐(1,2) == FT(0.01)
 
 
 # Line by line debug and test for `refine` function
@@ -116,7 +111,12 @@ Uᴳ = gustiness * cbrt(Jᵇ * hᵢ)
 # TODO: z0test to be redefined with `surface_args`, `similarity_scales` as args
 
 similarity_profile = ufunc
-compute_similarity_theory_fluxes(similarity_profile, 
+similarity_scales = refine_similarity_variables(Σ_est, ΔU, 
+                                     similarity_profile,
+                                     surface_state, 
+                                     atmos_state, param_set)
+
+fluxes = compute_similarity_theory_fluxes(similarity_profile, 
                                  surface_state,
                                  atmos_state, 
                                  param_set)
@@ -129,3 +129,4 @@ compute_similarity_theory_fluxes(similarity_profile,
 @info similarity_theory
 @info ufunc
 @info "With ufunc.L = $(ufunc.L) the Monin Obukhov length"
+@info fluxes

--- a/test/new_formulation.jl
+++ b/test/new_formulation.jl
@@ -5,8 +5,11 @@ import Thermodynamics as TD
 import SurfaceFluxes as SF
 import SurfaceFluxes.Parameters as SFP
 import SurfaceFluxes.UniversalFunctions.BusingerParams
+import SurfaceFluxes.Parameters.SurfaceFluxesParameters
 import SurfaceFluxes.UniversalFunctions as UF
 import ClimaParams as CP
+import ArtifactWrappers as AW
+import NCDatasets as NC
 
 # Assume constant values
 # For method tests define functions for roughness that return constant values
@@ -29,71 +32,231 @@ function z0test(surface_args, similarity_scales, atmos_state, param_set)
     return FT(0.015 * u★^2 / 9.81)
 end
 
+function generate_profiles(;FT=Float32, uf_params = UF.BusingerParams)
+    param_set = SurfaceFluxesParameters(FT, uf_params)
+    thermo_params = param_set.thermo_params
+    profiles = collect(TD.TestedProfiles.PhaseEquilProfiles(thermo_params, Array{FT}))
+    profiles_sfc = filter(p -> iszero(p.z), profiles)
+    profiles_int = filter(p -> !iszero(p.z), profiles)
+    ## Properties contained in `profiles_<sfc, int>`
+    ## :z, :T, :p, :RS, :e_int, :h, :ρ, 
+    ## :θ_liq_ice, :q_tot, :q_liq, :q_ice, :q_pt, :RH, 
+    ## :e_pot, :u, :v, :w, :e_kin, :phase_type
+    return profiles_sfc, profiles_int, param_set
+end
 
-atmos_state = AtmosState(
-                  FT(5),
-                  FT(1),
-                  FT(0.002),
-                  FT(298),
-                  FT(15),
-                  FT(1), # gustiness needs to be a function of u,v, ustar
-                  FT(100),
-                  (ρ=FT(1.20), arg𝑏=FT(0.01), arg𝑐=z0test),
-                )
+function get_result(; FT=Float32)
+    uf_params = UF.BusingerParams
+    profiles_sfc, profiles_int = generate_profiles(; uf_params)
+    function run_op(profiles_int, profiles_sfc)
+        atmos_state = AtmosState(
+                          profiles_int.u ./ 10,
+                          profiles_int.v ./ 10,
+                          profiles_int.q_tot,
+                          profiles_int.θ_liq_ice,
+                          profiles_int.z,
+                          FT(1), # gustiness needs to be a function of u,v, ustar
+                          FT(100),
+                          (ρ=profiles_int.ρ, arg𝑏=FT(0.01), arg𝑐=z0test),
+                        )
+        surface_state = SurfaceState(
+                          (𝑧0m=FT(0.01), 𝑧0θ=FT(0.01), 𝑧0q=z0test),
+                          FT(0),
+                          FT(0),
+                          profiles_sfc.q_tot,
+                          profiles_sfc.θ_liq_ice,
+                          FT(0),
+                          (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
+                        )
+        # Line by line debug and test for `refine` function
+        Δstate = state_differences(surface_state, atmos_state, Σ₀, param_set); 
+        (; 𝑧0m, 𝑧0θ, 𝑧0q) = surface_state.roughness_lengths
+        # Generic info block 
+        ζ₀ = FT(-10)
+        L★ = Δstate.Δh ./ ζ₀
+        sfc_params = SFP.uf_params(param_set)
+        similarity_theory = SFP.universal_func_type(param_set)
+        ufunc = UF.universal_func(similarity_theory, L★, sfc_params)
+        Σ_est = (momentum=FT(0.1),temperature=FT(0.01),water_vapor=FT(0.001))
+        ΔU_est = FT(10)
+        # Initial guess
+        similarity_profile = ufunc
+        similarity_scales = refine_similarity_variables(Σ_est, ΔU_est, 
+                                             similarity_profile,
+                                             surface_state, 
+                                             atmos_state, param_set)
+        fluxes = compute_similarity_theory_fluxes(similarity_profile, 
+                                         surface_state,
+                                         atmos_state, 
+                                         param_set)
+        fluxes.scale_vars
+    end
+    [run_op(ii, jj) for ii in profiles_int, jj in profiles_sfc]
+end
 
-surface_state = SurfaceState(
-                  (𝑧0m=FT(0.01), 𝑧0θ=FT(0.01), 𝑧0q=z0test),
-                  FT(0),
-                  FT(0),
-                  FT(0.003),
-                  FT(304),
-                  FT(0),
-                  (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
-                )
+function run_profiles()
+    PyCLES_output_dataset = AW.ArtifactWrapper(
+        @__DIR__,
+        "PyCLES_output",
+        AW.ArtifactFile[
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc", filename = "Gabls.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/toyvhbwmow3nz5bfa145m5fmcb2qbfuz.nc", filename = "DYCOMS_RF01.nc",),
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/jci8l11qetlioab4cxf5myr1r492prk6.nc", filename = "Bomex.nc",),
+        ],
+    )
+    #! format: on
+    PyCLES_output_dataset_path = AW.get_data_folder(PyCLES_output_dataset)
+    files = ["DYCOMS_RF01.nc", "Bomex.nc", "Rico.nc", "Gabls.nc"];
+    for f in files
+        @info "Casename: $f"
 
+        nt = NC.NCDataset(joinpath(PyCLES_output_dataset_path, f), "r") do data
+            prof = data.group["profiles"]
+            timeseries = data.group["timeseries"]
+            z = Array(data["z_half"])
+            u = Array(prof["u_mean"])
+            v = Array(prof["v_mean"])
+            qt = Array(prof["qt_mean"])
+            ql = Array(prof["ql_mean"])
+            ρ = Array(prof["rho"])
+            p0 = Array(prof["p0"])
+            b = Array(prof["buoyancy_mean"])
+            θli = Array(prof["thetali_mean"]) # Care with variable names across cases ()?
+            T = Array(prof["temperature_mean"]) # Care with variable names across cases ()?
+            SHF = Array(timeseries["shf_surface_mean"]) # Care with variable names across cases ()?
+            LHF = Array(timeseries["lhf_surface_mean"]) # Care with variable names across cases ()?
+            (; z, u, v, qt, ql, ρ, p0, b, θli, T, SHF, LHF)
+        end
+        z, u, v, qt, ql, ρ, p0, b, θli, T, SHF, LHF = nt
 
-# Line by line debug and test for `refine` function
-gustiness = atmos_state.gustiness_parameter
-Δstate = state_differences(surface_state, atmos_state, Σ₀, param_set); 
-(; 𝑧0m, 𝑧0θ, 𝑧0q) = surface_state.roughness_lengths
+        function getval(X) # Consider only the last timestep
+            X[:, end]
+        end
 
-# Generic info block 
+        # Data at first interior node (x_in)
+        # TODO Make sure that the first node ii = 1 is at the "surface"
+        # for the tests to be consistent
+        ii = 2
 
-ζ₀ = FT(-10)
-L★ = Δstate.Δh ./ ζ₀
-sfc_params = SFP.uf_params(param_set)
-similarity_theory = SFP.universal_func_type(param_set)
-ufunc = UF.universal_func(similarity_theory, L★, sfc_params)
-# We shouldn't need both these! ζ and `BusingerParams` should be enough (at the user level)
-# to define all similarity functions 𝜓, 𝜙
+        shf = mean(getval(SHF))
+        lhf = mean(getval(LHF))
 
-Σ_est = (momentum=FT(0.1),temperature=FT(0.01),water_vapor=FT(0.001))
-ΔU_est = FT(10)
+        z_in = z[ii]
+        u_in = getval(u)[ii]
+        v_in = getval(v)[ii]
+        b_in = getval(b)[ii]
+        ρ_in = getval(ρ)[ii]
+        θ_in = getval(θli)[ii]
+        T_in = getval(T)[ii]
+        qt_in = getval(qt)[ii]
 
-# Initial guess
-u★ = Σ_est.momentum
-θ★ = Σ_est.temperature
-q★ = Σ_est.water_vapor
-uτ = ΔU_est
+        # Surface values for variables
+        jj = 1
+        u_sfc = FT(0)
+        v_sfc = FT(0)
+        b_sfc = getval(b)[jj]
+        ρ_sfc = getval(ρ)[jj]
+        qt_sfc = getval(qt)[jj]
+        θ_sfc = getval(θli)[jj]
+        T_sfc = getval(T)[jj]
+        z_sfc = FT(0)
 
-similarity_profile = ufunc
-similarity_scales = refine_similarity_variables(Σ_est, ΔU_est, 
-                                     similarity_profile,
-                                     surface_state, 
-                                     atmos_state, param_set)
+        # Roughness
+        ## Roughness lengths
+        z0m = FT(0.001)
+        z0b = FT(0.001)
 
-fluxes = compute_similarity_theory_fluxes(similarity_profile, 
-                                 surface_state,
-                                 atmos_state, 
-                                 param_set)
+        ts_sfc = TD.PhaseEquil_ρθq(thermo_params, ρ_sfc, θ_sfc, qt_sfc)
+        ts_in = TD.PhaseEquil_ρθq(thermo_params, ρ_in, θ_in, qt_in)
 
-#### Diagnostics
-@info ufunc
-@info "With ufunc.L = $(ufunc.L) the Monin Obukhov length"
-@info fluxes.sensible_heat
-@info fluxes.latent_heat
-@info fluxes.water_vapor
-@info fluxes.x_momentum
-@info fluxes.y_momentum
-@info fluxes.r_ae
-@info fluxes.scale_vars
+        u_in = (FT(u_in), FT(v_in))
+        u_sfc = (FT(u_sfc), FT(v_sfc))
+
+        state_sfc = SF.StateValues(z_sfc, u_sfc, ts_sfc)
+        state_in = SF.StateValues(z_in, u_in, ts_in)
+
+        kwargs = (; state_in, state_sfc, z0m, z0b)
+
+        # Initial guess
+        sfc_params = SFP.uf_params(param_set)
+        similarity_theory = SFP.universal_func_type(param_set)
+
+        if f == "DYCOMS_RF01.nc"
+            atmos_state = AtmosState(
+                              u_in[1],
+                              u_in[2],
+                              qt_in,
+                              θ_in,
+                              z_in,
+                              FT(1), # gustiness needs to be a function of u,v, ustar
+                              FT(100),
+                              (ρ=ρ_sfc, arg𝑏=FT(0.01), arg𝑐=z0test),
+                            )
+            surface_state = SurfaceState(
+                              (𝑧0m=FT(0.001), 𝑧0θ=FT(0.001), 𝑧0q=z0test),
+                              FT(0),
+                              FT(0),
+                              qt_sfc,
+                              θ_sfc,
+                              FT(0),
+                              (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
+                            )
+            # Line by line debug and test for `refine` function
+            Δstate = state_differences(surface_state, atmos_state, Σ₀, param_set); 
+            ζ₀ = FT(-10)
+            L★ = Δstate.Δh ./ ζ₀
+            ufunc = UF.universal_func(similarity_theory, L★, sfc_params)
+            Σ_est = (momentum=FT(0.1),temperature=FT(0.01),water_vapor=FT(0.001))
+            ΔU_est = FT(10)
+            similarity_profile = ufunc
+            (; 𝑧0m, 𝑧0θ, 𝑧0q) = surface_state.roughness_lengths
+            fluxes = compute_similarity_theory_fluxes(similarity_profile, 
+                                             surface_state,
+                                             atmos_state, 
+                                             param_set)
+            @show fluxes
+        elseif f == "Bomex.nc"
+            #sc = SF.FluxesAndFrictionVelocity(state_in, state_sfc, shf, lhf, FT(0.28), z0m, z0b)
+        elseif f == "Rico.nc"
+            #sc = SF.Coefficients(state_in, state_sfc, FT(0.001229), FT(0.001094), z0m, z0b)
+        elseif f == "Gabls.nc"
+            atmos_state = AtmosState(
+                              u_in[1],
+                              u_in[2],
+                              qt_in,
+                              θ_in,
+                              z_in,
+                              FT(1), # gustiness needs to be a function of u,v, ustar
+                              FT(100),
+                              (ρ=ρ_sfc, arg𝑏=FT(0.01), arg𝑐=z0test),
+                            )
+            surface_state = SurfaceState(
+                              (𝑧0m=FT(0.001), 𝑧0θ=FT(0.001), 𝑧0q=z0test),
+                              FT(0),
+                              FT(0),
+                              qt_sfc,
+                              θ_sfc,
+                              FT(0),
+                              (arg𝑎=FT(0.01), arg𝑏=FT(0.01), arg𝑐=z0test),
+                            )
+            # Line by line debug and test for `refine` function
+            Δstate = state_differences(surface_state, atmos_state, Σ₀, param_set); 
+            (; 𝑧0m, 𝑧0θ, 𝑧0q) = surface_state.roughness_lengths
+            # Initial guess
+            ζ₀ = FT(-10)
+            L★ = Δstate.Δh ./ ζ₀
+            sfc_params = SFP.uf_params(param_set)
+            similarity_theory = SFP.universal_func_type(param_set)
+            ufunc = UF.universal_func(similarity_theory, L★, sfc_params)
+            Σ_est = (momentum=FT(0.1),temperature=FT(0.01),water_vapor=FT(0.001))
+            ΔU_est = FT(10)
+            similarity_profile = ufunc
+            fluxes = compute_similarity_theory_fluxes(similarity_profile, 
+                                             surface_state,
+                                             atmos_state, 
+                                             param_set)
+            @show fluxes
+        end
+    end
+end

--- a/test/new_formulation.jl
+++ b/test/new_formulation.jl
@@ -85,4 +85,10 @@ fluxes = compute_similarity_theory_fluxes(similarity_profile,
 #### Diagnostics
 @info ufunc
 @info "With ufunc.L = $(ufunc.L) the Monin Obukhov length"
-@info fluxes
+@info fluxes.sensible_heat
+@info fluxes.latent_heat
+@info fluxes.water_vapor
+@info fluxes.x_momentum
+@info fluxes.y_momentum
+@info fluxes.r_ae
+@info fluxes.scale_vars

--- a/test/new_formulation_land.jl
+++ b/test/new_formulation_land.jl
@@ -1,0 +1,203 @@
+include("../src/similarity_theory.jl")
+
+using Test
+import Thermodynamics as TD
+import SurfaceFluxes as SF
+import SurfaceFluxes.Parameters as SFP
+import SurfaceFluxes.UniversalFunctions.BusingerParams
+import SurfaceFluxes.UniversalFunctions as UF
+import ClimaParams as CP
+
+FT = Float32
+# Parameters (ClimaParams types)
+param_set = SFP.SurfaceFluxesParameters(FT, BusingerParams)
+thermo_params = param_set.thermo_params
+
+# Things that do not vary between test sets
+h_a = FT(15)
+u_a = FT(5)
+v_a = FT(1)
+gustiness = FT(1)
+T_a = FT(298)
+ρ_a = FT(1.2)
+atmos_args = (;ρ = ρ_a,)
+q_sat_a = TD.q_vap_saturation_generic(
+    thermo_params,
+    T_a,
+    ρ_a,
+    TD.Liquid(),
+)
+ζ₀ = FT(-10)
+L★ = h_a ./ ζ₀
+sfc_params = SFP.uf_params(param_set)
+similarity_theory = SFP.universal_func_type(param_set)
+similarity_profile = UF.universal_func(similarity_theory, L★, sfc_params)
+similarity_profile = ufunc
+
+@testset "q_atmos < q_land, β > 0, T_land = T_atmos" begin
+    # Surface state
+    function q_surface(surface_args, similarity_scales, atmos_state, param_set)
+        q_a = atmos_state.q_a
+        β = surface_args.β
+        θ_s = surface_args.θ_s # instead pass surface_state as arg
+        θ_a = atmos_state.θ_a
+        ρ_a = atmos_state.args.ρ
+        cv_m = TD.cv_m(thermo_params, TD.PhasePartition(q_a))
+        R_m =  TD.gas_constant_air(thermo_params, TD.PhasePartition(q_a))
+        ρ_s = ρ_a * (θ_s/θ_a)^(cv_m/R_m)
+        q_sat = TD.q_vap_saturation_generic(
+            thermo_params,
+            θ_s,
+            ρ_s,
+            TD.Liquid(),
+        )
+        return q_sat*β + (1-β)*q_a
+    end
+    T_s = T_a
+    surface_args = (; β = FT(0.5), θ_s = T_s)
+    surface_state = SurfaceState(
+        (𝑧0m=FT(0.01), 𝑧0θ=FT(0.01), 𝑧0q=FT(0.01)),
+        FT(0), #u
+        FT(0), # v
+        q_surface, # q function
+        T_a, # θ
+        FT(0), # h
+        surface_args,
+    )
+
+    # Atmos state (partial, we will vary q_a)
+    q_a = [q_sat_a*0.01f0, q_sat_a*0.5f0, q_sat_a-eps(FT)]
+    similarity_profile = ufunc
+    lhf = []
+    for atmos_q in q_a
+        atmos_state = AtmosState(
+            u_a, #u
+            v_a, #v
+            atmos_q, #q
+            T_a, # θ
+            h_a, # h
+            gustiness, # gustiness
+            FT(100), #h boundary layer
+            atmos_args # extra args
+        )
+        fluxes = compute_similarity_theory_fluxes(similarity_profile, 
+                                                  surface_state,
+                                                  atmos_state, 
+                                                  param_set)
+        
+        @test fluxes.sensible_heat ≈ 0
+        push!(lhf, fluxes.latent_heat)
+    end
+    @test abs(lhf[2]/lhf[1] - FT(0.5)) < 0.05
+    @test lhf[3] < 0.01
+    @test all(lhf .> 0)
+end
+
+
+@testset "q_atmos > q_land, β <= 1, T_land < T_atmos" begin
+    #Surface state (partial, surface_args specified below)
+    T_s = FT(280)
+    function q_surface(surface_args, similarity_scales, atmos_state, param_set)
+        q_a = atmos_state.q_a
+        β = surface_args.β
+        θ_s = surface_args.θ_s # instead pass surface_state as arg
+        θ_a = atmos_state.θ_a
+        ρ_a = atmos_state.args.ρ
+        cv_m = TD.cv_m(thermo_params, TD.PhasePartition(q_a))
+        R_m =  TD.gas_constant_air(thermo_params, TD.PhasePartition(q_a))
+        ρ_s = ρ_a * (θ_s/θ_a)^(cv_m/R_m)
+        q_sat = TD.q_vap_saturation_generic(
+            thermo_params,
+            θ_s,
+            ρ_s,
+            TD.Liquid(),
+        )
+        return q_sat*β + (1-β)*q_a
+    end
+
+    # Atmos state (full)
+    atmos_state = AtmosState(
+        u_a, #u
+        v_a, #v
+        q_sat_a, #q
+        T_a, # θ
+        h_a, # h
+        gustiness, # gustiness
+        FT(100), #h boundary layer
+        atmos_args # extra args
+    )
+    similarity_profile = ufunc
+    lhf = []
+    for β in [FT(0), FT(0.5), FT(1)]
+        surface_args = (; β = β, θ_s = T_s)
+        surface_state = SurfaceState(
+            (𝑧0m=FT(0.01), 𝑧0θ=FT(0.01), 𝑧0q=FT(0.01)),
+            FT(0), #u
+            FT(0), # v
+            q_surface, # q function
+            T_s, # θ
+            FT(0), # h
+            surface_args,
+        )
+        fluxes = compute_similarity_theory_fluxes(similarity_profile, 
+                                                  surface_state,
+                                                  atmos_state, 
+                                                  param_set)
+        
+        push!(lhf, fluxes.latent_heat)
+    end
+    @test abs(lhf[2]/lhf[3] - FT(0.5)) < 0.05
+    @test all(lhf[2:3] .<0)
+    @test lhf[1] ≈ 0
+end
+
+@testset "q_atmos = q_land, T_atmos = T_land, β = 0" begin
+    #Surface state
+    T_s = T_a
+    function q_surface(surface_args, similarity_scales, atmos_state, param_set)
+        q_a = atmos_state.q_a
+        β = surface_args.β
+        θ_s = surface_args.θ_s # instead pass surface_state as arg
+        θ_a = atmos_state.θ_a
+        ρ_a = atmos_state.args.ρ
+        cv_m = TD.cv_m(thermo_params, TD.PhasePartition(q_a))
+        R_m =  TD.gas_constant_air(thermo_params, TD.PhasePartition(q_a))
+        ρ_s = ρ_a * (θ_s/θ_a)^(cv_m/R_m)
+        q_sat = TD.q_vap_saturation_generic(
+            thermo_params,
+            θ_s,
+            ρ_s,
+            TD.Liquid(),
+        )
+        return q_sat*β + (1-β)*q_a
+    end
+    surface_args = (; β = 0f0, θ_s = T_s)
+    surface_state = SurfaceState(
+        (𝑧0m=FT(0.01), 𝑧0θ=FT(0.01), 𝑧0q=FT(0.01)),
+        FT(0), #u
+        FT(0), # v
+        q_surface, # q function
+        T_s, # θ
+        FT(0), # h
+        surface_args,
+    )
+    
+    # Atmos state
+    atmos_state = AtmosState(
+        u_a, #u
+        v_a, #v
+        q_a, #q
+        T_a, # θ
+        h_a, # h
+        gustiness, # gustiness
+        FT(100), #h boundary layer
+        atmos_args # extra args
+    )
+    fluxes = compute_similarity_theory_fluxes(similarity_profile, 
+                                              surface_state,
+                                              atmos_state, 
+                                              param_set)
+    
+    @test fluxes.latent_heat ≈ 0
+    @test fluxes.sensible_heat ≈ 0
+end

--- a/test/new_formulation_land.jl
+++ b/test/new_formulation_land.jl
@@ -154,6 +154,7 @@ end
 @testset "q_atmos = q_land, T_atmos = T_land, β = 0" begin
     #Surface state
     T_s = T_a
+    # TODO: `surface_state` as arg in `surface_variable` function
     function q_surface(surface_args, similarity_scales, atmos_state, param_set)
         q_a = atmos_state.q_a
         β = surface_args.β
@@ -197,7 +198,6 @@ end
                                               surface_state,
                                               atmos_state, 
                                               param_set)
-    
     @test fluxes.latent_heat ≈ 0
     @test fluxes.sensible_heat ≈ 0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,10 +153,6 @@ end
 @testset "Test generated thermodynamic states" begin
     include("test_convergence.jl")
 end
-@testset "Test generated thermodynamic states" begin
-    include("test_convergence.jl")
-end
-
 @testset "Quality assurance" begin
     include("aqua.jl")
 end

--- a/test/test_profiles.jl
+++ b/test/test_profiles.jl
@@ -25,7 +25,6 @@ PyCLES_output_dataset = AW.ArtifactWrapper(
 )
 #! format: on
 PyCLES_output_dataset_path = AW.get_data_folder(PyCLES_output_dataset)
-
 files = ["DYCOMS_RF01.nc", "Bomex.nc", "Rico.nc", "Gabls.nc"];
 for f in files
     @info "Casename: $f"
@@ -108,4 +107,5 @@ for f in files
         sc = SF.ValuesOnly(state_in, state_sfc, z0m, z0b)
     end
     result = SF.surface_conditions(param_set, sc)
+    @show result
 end


### PR DESCRIPTION
Towards re-designing interfaces to use fixed-point iterations compatible with ClimaOcean / ClimaLand requirements. 
Linked issue : SurfaceFluxes #180 

Progress: This PR demonstrates modifications to the surface flux interfaces to allow ocean and land properties to be more easily ingested by the solver functions. A new module "SimilarityTheory" (suggested name) will contain these changes which, following verification against current ClimaLand / ClimaOcean interfaces can be used a single tool for all model components. `test/new_formulation.jl` demonstrates simple use cases of the proposed changes. 

Status: Paused while we prioritise the Dycore paper and related code changes. 
