### PR TITLE
Update climacommon to 2025_03_18

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_10_09
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

The most recent version of climacommon uses the newly released Julia 1.11.4.

This version is needed to use CUDA 5.7, so I would recommend updating.