### PR TITLE
update Github actions

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@latest
       with:
-        version: '1.10'
+        version: '1.11'
 
     - name: Test with coverage
       env:
@@ -37,4 +37,3 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
       if: success()
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     tags: '*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ci ${{ matrix.version }} - ${{ matrix.os }}
@@ -13,6 +17,7 @@ jobs:
       matrix:
         version:
           - '1.10'
+          - '1.11'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -22,19 +27,10 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v5
         with:
           file: lcov.info

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update Github actions to run tests on Julia 1.11

## Content
- [x] run tests on Julia 1.11 in addition to 1.10
- [x] run code coverage and docs build on 1.11 instead of 1.10
- [x] unit tests: cancel previous builds in concurrency group when triggered (i.e. existing runs on this branch/PR)
- [x] unit tests: use [julia-actions/cache](https://github.com/julia-actions/cache) which is a Julia-specific wrapper around `actions/cache`, instead of using `actions/cache` directly (similar to what we were doing before, but simpler for us to use)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
