### PR TITLE
Simplify UniversalFunctions.jl type structure

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,9 +56,9 @@ SurfaceFluxes.UniversalFunctions
 ```
 
 ```@docs
-SurfaceFluxes.UniversalFunctions.Gryanik
-SurfaceFluxes.UniversalFunctions.Grachev
-SurfaceFluxes.UniversalFunctions.Businger
+SurfaceFluxes.UniversalFunctions.GryanikParams
+SurfaceFluxes.UniversalFunctions.GrachevParams
+SurfaceFluxes.UniversalFunctions.BusingerParams
 ```
 
 ```@docs

--- a/docs/src/plot_bonan_profiles.jl
+++ b/docs/src/plot_bonan_profiles.jl
@@ -13,7 +13,6 @@ import Plots
 FT = Float32
 param_set = SurfaceFluxesParameters(FT, UniversalFunctions.BusingerParams)
 thermo_params = param_set.thermo_params
-uft = UniversalFunctions.universal_func_type(typeof(param_set.ufp))
 
 # Define surface parameters. Note that recovery parameters purely depend on LMO, scale variables and Δ(interior - surface) 
 # for each variable

--- a/docs/src/plot_universal_functions.jl
+++ b/docs/src/plot_universal_functions.jl
@@ -27,10 +27,8 @@ function save_ϕ_figs(
 )
     Plots.plot()
     for ufp in ufps
-        uft = UF.universal_func_type(typeof(ufp))
-        uf = UF.universal_func(uft, L, ufp)
-        ϕ_m = UF.phi.(uf, ζ, UF.MomentumTransport())
-        label = "$(typeof(uf).name)"
+        ϕ_m = UF.phi.(ufp, ζ, UF.MomentumTransport())
+        label = "$(typeof(ufp))"
         Plots.plot!(
             ζ,
             ϕ_m;
@@ -45,10 +43,8 @@ function save_ϕ_figs(
     Plots.savefig("$(fig_prefix)_phi_m.svg")
     Plots.plot()
     for ufp in ufps
-        uft = UF.universal_func_type(typeof(ufp))
-        uf = UF.universal_func(uft, L, ufp)
-        ϕ_h = UF.phi.(uf, ζ, UF.HeatTransport())
-        label = "$(typeof(uf).name)"
+        ϕ_h = UF.phi.(ufp, ζ, UF.HeatTransport())
+        label = "$(typeof(ufp))"
         Plots.plot!(
             ζ,
             ϕ_h;
@@ -72,10 +68,8 @@ function save_ψ_figs(
 )
     Plots.plot()
     for ufp in ufps
-        uft = UF.universal_func_type(typeof(ufp))
-        uf = UF.universal_func(uft, L, ufp)
-        ψ_m = UF.psi.(uf, ζ, UF.MomentumTransport())
-        label = "$(typeof(uf).name)"
+        ψ_m = UF.psi.(ufp, ζ, UF.MomentumTransport())
+        label = "$(typeof(ufp))"
         Plots.plot!(
             ζ,
             ψ_m;
@@ -90,10 +84,8 @@ function save_ψ_figs(
     Plots.savefig("$(fig_prefix)_psi_m.svg")
     Plots.plot()
     for ufp in ufps
-        uft = UF.universal_func_type(typeof(ufp))
-        uf = UF.universal_func(uft, L, ufp)
-        ψ_h = UF.psi.(uf, ζ, UF.HeatTransport())
-        label = "$(typeof(uf).name)"
+        ψ_h = UF.psi.(ufp, ζ, UF.HeatTransport())
+        label = "$(typeof(ufp))"
         Plots.plot!(
             ζ,
             ψ_h;
@@ -131,7 +123,6 @@ save_ϕ_figs(
     yaxis = :log10,
     fig_prefix = "Gryanik3",
 )
-
 
 # Businger Plots
 save_ϕ_figs(

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -25,9 +25,6 @@ thermodynamics_params(ps::SurfaceFluxesParameters) = ps.thermo_params
 uf_params(ps::SurfaceFluxesParameters) = ps.ufp
 von_karman_const(ps::SurfaceFluxesParameters) = ps.von_karman_const
 
-universal_func_type(::SurfaceFluxesParameters{FT, AUFPS}) where {FT, AUFPS} =
-    UF.universal_func_type(AUFPS)
-
 for var in fieldnames(TDPS)
     @eval $var(ps::ASFP) = TD.Parameters.$var(thermodynamics_params(ps))
 end

--- a/src/UniversalFunctions.jl
+++ b/src/UniversalFunctions.jl
@@ -13,27 +13,8 @@ module UniversalFunctions
 import DocStringExtensions
 const DSE = DocStringExtensions
 
-const FTypes = Union{Real, AbstractArray}
-
-abstract type AbstractUniversalFunction{FT <: FTypes} end
-const AUF = AbstractUniversalFunction
-
-#=
-    AbstractUniversalFunctionType
-
-Internal abstract type. Subtypes mirror `AbstractUniversalFunction`s.
-These mirrored subtypes are needed due to several constraints:
- - Types we pass in concrete types to avoid UnionAll types (which incur allocations)
- - We cannot pass in concrete types, e.g. `Businger{FT, typeof(param_set)}`
-   because we must be able to use ForwardDiff, which requires changing `FT`.
-=#
-abstract type AbstractUniversalFunctionType end
-const AUFT = AbstractUniversalFunctionType
-
 abstract type AbstractUniversalFunctionParameters{FT <: Real} end
 const AUFP = AbstractUniversalFunctionParameters
-
-Base.eltype(uf::AbstractUniversalFunction{FT}) where {FT} = FT
 
 #####
 ##### Interface
@@ -43,8 +24,8 @@ abstract type AbstractTransportType end
 struct MomentumTransport <: AbstractTransportType end
 struct HeatTransport <: AbstractTransportType end
 
-Base.broadcastable(tt::AbstractUniversalFunction) = tuple(tt)
 Base.broadcastable(tt::AbstractTransportType) = tuple(tt)
+Base.broadcastable(p::AbstractUniversalFunctionParameters) = tuple(p)
 
 """
     phi
@@ -74,25 +55,36 @@ function Psi end
 ##### Forwarding methods for free parameters
 #####
 
-Pr_0(uf::AUF) = uf.params.Pr_0
-a_m(uf::AUF) = uf.params.a_m
-a_h(uf::AUF) = uf.params.a_h
-b_m(uf::AUF) = uf.params.b_m
-b_h(uf::AUF) = uf.params.b_h
-c_h(uf::AUF) = uf.params.c_h
-c_m(uf::AUF) = uf.params.c_m
-d_h(uf::AUF) = uf.params.d_h
-d_m(uf::AUF) = uf.params.d_m
-ζ_a(uf::AUF) = uf.params.ζ_a
-γ(uf::AUF) = uf.params.γ
+# Parameter-struct accessors (allow calling phi/psi/Psi with params directly)
+Pr_0(p::AUFP) = p.Pr_0
+a_m(p::AUFP) = p.a_m
+a_h(p::AUFP) = p.a_h
+b_m(p::AUFP) = p.b_m
+b_h(p::AUFP) = p.b_h
+c_h(p::AUFP) = p.c_h
+c_m(p::AUFP) = p.c_m
+d_h(p::AUFP) = p.d_h
+d_m(p::AUFP) = p.d_m
+ζ_a(p::AUFP) = p.ζ_a
+γ(p::AUFP) = p.γ
 
-π_group(uf::AUF, ::HeatTransport) = Pr_0(uf)
-π_group(::AUF, ::MomentumTransport) = 1
+# Parameter-struct π-group (avoid constructing UF just to get scalar π)
+π_group(p::AUFP, ::HeatTransport) = Pr_0(p)
+π_group(::AUFP, ::MomentumTransport) = 1
 
 #####
 ##### Businger
 #####
+"""
+    BusingerParams{FT} <: AbstractUniversalFunctionParameters{FT}
 
+Free parameters for the Businger universal stability and stability correction
+functions.
+
+# Fields
+
+$(DSE.FIELDS)
+"""
 Base.@kwdef struct BusingerParams{FT} <: AbstractUniversalFunctionParameters{FT}
     Pr_0::FT
     a_m::FT
@@ -103,142 +95,111 @@ Base.@kwdef struct BusingerParams{FT} <: AbstractUniversalFunctionParameters{FT}
     γ::FT
 end
 
-"""
-    Businger
-
-# Reference
-
- - [Nishizawa2018](@cite)
-
-# Original research
-
- - [Businger1971](@cite)
-
-# Equations in reference:
-
-    `ϕ_m`: Eq. A1
-    `ϕ_h`: Eq. A2
-    `ψ_m`: Eq. A3
-    `ψ_h`: Eq. A4
-
-# Fields
-
-$(DSE.FIELDS)
-"""
-struct Businger{FT, PS <: BusingerParams} <: AbstractUniversalFunction{FT}
-    "Monin-Obhukov Length"
-    L::FT
-    params::PS
-end
-
-struct BusingerType <: AbstractUniversalFunctionType end
-Businger() = BusingerType()
-
 # Nishizawa2018 Eq. A7
-function f_momentum(uf::Businger, ζ)
-    FT = eltype(uf)
-    return sqrt(sqrt(1 - FT(b_m(uf)) * ζ))
-end
+f_momentum(p::BusingerParams, ζ) = sqrt(sqrt(1 - typeof(ζ)(b_m(p)) * ζ))
 
 # Nishizawa2018 Eq. A8
-function f_heat(uf::Businger, ζ)
-    FT = eltype(uf)
-    return sqrt(1 - FT(b_h(uf)) * ζ)
-end
+f_heat(p::BusingerParams, ζ) = sqrt(1 - typeof(ζ)(b_h(p)) * ζ)
 
-function phi(uf::Businger, ζ, ::MomentumTransport)
+function phi(p::BusingerParams, ζ, ::MomentumTransport)
+    FT = eltype(ζ)
     if ζ < 0
         # Businger1971 Eq. A1 (ζ < 0)
-        f_m = f_momentum(uf, ζ)
-        return 1 / f_m
+        f_m = f_momentum(p, ζ)
+        return FT(1) / FT(f_m)
     else
         # Businger1971 Eq. A1 (ζ >= 0)
-        FT = eltype(uf)
-        _a_m = FT(a_m(uf))
-        return _a_m * ζ + 1
+        _a_m = FT(a_m(p))
+        return _a_m * ζ + FT(1)
     end
 end
 
-function phi(uf::Businger, ζ, tt::HeatTransport)
+function phi(p::BusingerParams, ζ, tt::HeatTransport)
+    FT = eltype(ζ)
     if ζ < 0
         # Businger1971 Eq. A2 (ζ < 0)
-        f_h = f_heat(uf, ζ)
-        return 1 / f_h
+        f_h = f_heat(p, ζ)
+        return FT(1) / FT(f_h)
     else
         # Businger1971 Eq. A2 (ζ >= 0)
-        FT = eltype(uf)
-        _a_h = FT(a_h(uf))
-        _π_group = FT(π_group(uf, tt))
-        return _a_h * ζ / _π_group + 1
+        _a_h = FT(a_h(p))
+        _π_group = FT(π_group(p, tt))
+        return _a_h * ζ / _π_group + FT(1)
     end
 end
 
-function psi(uf::Businger, ζ, ::MomentumTransport)
-    FT = eltype(uf.L)
+function psi(p::BusingerParams, ζ, ::MomentumTransport)
+    FT = eltype(ζ)
+    if abs(ζ) < eps(FT)
+        return FT(0)
+    end
     if ζ < 0
         # Businger1971 Eq. A3 (ζ < 0)
-        f_m = f_momentum(uf, ζ)
+        f_m = f_momentum(p, ζ)
         log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
-        return log_term - 2 * atan(f_m) + FT(π) / 2
+        return FT(log_term - 2 * atan(f_m) + π / 2)
     else
         # Businger1971 Eq. A3 (ζ >= 0)
-        _a_m = FT(a_m(uf))
+        _a_m = FT(a_m(p))
         return -_a_m * ζ
     end
 end
 
-function psi(uf::Businger, ζ, tt::HeatTransport)
+function psi(p::BusingerParams, ζ, tt::HeatTransport)
+    FT = eltype(ζ)
+    if abs(ζ) < eps(FT)
+        return FT(0)
+    end
     if ζ < 0
         # Businger1971 Eq. A4 (ζ < 0)
-        f_h = f_heat(uf, ζ)
-        return 2 * log((1 + f_h) / 2)
+        f_h = f_heat(p, ζ)
+        return FT(2 * log((1 + f_h) / 2))
     else
         # Businger1971 Eq. A4 (ζ >= 0)
-        FT = eltype(uf)
-        _a_h = FT(a_h(uf))
-        _π_group = FT(π_group(uf, tt))
+        _a_h = FT(a_h(p))
+        _π_group = FT(π_group(p, tt))
         return -_a_h * ζ / _π_group
     end
 end
 
-function Psi(uf::Businger, ζ, tt::MomentumTransport)
-    FT = eltype(uf)
+function Psi(p::BusingerParams, ζ, tt::MomentumTransport)
+    FT = eltype(ζ)
     if ζ >= 0
         # Nishizawa2018 Eq. A5 and A13 (ζ >= 0)
-        _a_m = FT(a_m(uf))
+        _a_m = FT(a_m(p))
         return -_a_m * ζ / 2
     else
         if abs(ζ) < eps(FT)
             # Nishizawa2018 Eq. A13 (ζ < 0)
-            return -FT(b_m(uf)) * ζ / FT(8)
+            return -FT(b_m(p)) * ζ / FT(8)
         else
             # Nishizawa2018 Eq. A5 (ζ < 0)
-            f_m = f_momentum(uf, ζ)
+            f_m = f_momentum(p, ζ)
             log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
             π_term = FT(π) / 2
             tan_term = 2 * atan(f_m)
             cubic_term = (1 - f_m^3) / (12 * ζ)
-            return log_term - tan_term + π_term - 1 + cubic_term
+            return FT(log_term - tan_term + π_term - 1 + cubic_term)
         end
     end
 end
 
-function Psi(uf::Businger, ζ, tt::HeatTransport)
-    FT = eltype(uf)
-    _a_h = FT(a_h(uf))
+function Psi(p::BusingerParams, ζ, tt::HeatTransport)
+    FT = eltype(ζ)
+    _a_h = FT(a_h(p))
     if ζ >= 0
         # Nishizawa2018 Eq. A6 and A14 (ζ >= 0)
-        _π_group = FT(π_group(uf, tt))
+        _π_group = FT(π_group(p, tt))
         return -_a_h * ζ / (2 * _π_group)
     else
         if abs(ζ) < eps(FT)
             # Nishizawa2018 Eq. A14 (ζ < 0)
-            return -FT(b_h(uf)) * ζ / 4
+            return -FT(b_h(p)) * ζ / 4
         else
             # Nishizawa2018 Eq. A6 (ζ < 0)
-            f_h = f_heat(uf, ζ)
+            f_h = f_heat(p, ζ)
             log_term = 2 * log((1 + f_h) / 2)
-            return log_term + 2 * (1 - f_h) / (FT(b_h(uf)) * ζ) - 1
+            return FT(log_term + 2 * (1 - f_h) / (FT(b_h(p)) * ζ) - 1)
         end
     end
 end
@@ -247,6 +208,16 @@ end
 ##### Gryanik
 #####
 
+"""
+    GryanikParams{FT} <: AbstractUniversalFunctionParameters{FT}
+
+Free parameters for the Gryanik universal stability and stability correction
+functions.
+
+# Fields
+
+$(DSE.FIELDS)
+"""
 Base.@kwdef struct GryanikParams{FT} <: AbstractUniversalFunctionParameters{FT}
     Pr_0::FT
     a_m::FT
@@ -257,145 +228,111 @@ Base.@kwdef struct GryanikParams{FT} <: AbstractUniversalFunctionParameters{FT}
     γ::FT
 end
 
-"""
-    Gryanik <: AbstractUniversalFunction{FT}
-
-# References
- - [Gryanik2020](@cite)
-
-# Equations in reference:
-
-    `ϕ_m`: Eq. 32
-    `ϕ_h`: Eq. 33
-    `ψ_m`: Eq. 34
-    `ψ_h`: Eq. 35
-
-# Gryanik et al. (2020) functions are used in stable conditions
-# In unstable conditions the functions of Businger (1971) are
-# assigned by default.
-
-# Fields
-
-$(DSE.FIELDS)
-"""
-struct Gryanik{FT, PS <: GryanikParams} <: AbstractUniversalFunction{FT}
-    "Monin-Obhukov Length"
-    L::FT
-    params::PS
-end
-
-struct GryanikType <: AbstractUniversalFunctionType end
-Gryanik() = GryanikType()
-
 # Nishizawa2018 Eq. A7
-f_momentum(uf::Gryanik, ζ) = sqrt(sqrt(1 - 15 * ζ))
+f_momentum(::GryanikParams, ζ) = sqrt(sqrt(1 - 15 * ζ))
 
 # Nishizawa2018 Eq. A8
-f_heat(uf::Gryanik, ζ) = sqrt(1 - 9 * ζ)
+f_heat(::GryanikParams, ζ) = sqrt(1 - 9 * ζ)
 
-function phi(uf::Gryanik, ζ, tt::MomentumTransport)
-    FT = eltype(uf)
+function phi(p::GryanikParams, ζ, tt::MomentumTransport)
+    FT = eltype(ζ)
     if ζ > 0
         # Gryanik2020 Eq. 32
-        _a_m = FT(a_m(uf))
-        _b_m = FT(b_m(uf))
-        return 1 + (_a_m * ζ) / (1 + _b_m * ζ)^(FT(2 / 3))
+        _a_m = FT(a_m(p))
+        _b_m = FT(b_m(p))
+        return FT(1) + (_a_m * ζ) / (1 + _b_m * ζ)^(FT(2 / 3))
     else
         # Nishizawa2018 Eq. A1 (ζ <= 0)
-        f_m = f_momentum(uf, ζ)
-        return 1 / f_m
+        f_m = f_momentum(p, ζ)
+        return FT(1) / FT(f_m)
     end
 end
 
-function phi(uf::Gryanik, ζ, tt::HeatTransport)
-    FT = eltype(uf)
+function phi(p::GryanikParams, ζ, tt::HeatTransport)
+    FT = eltype(ζ)
     if ζ > 0
         # Gryanik2020 Eq. 33
-        _Pr_0 = FT(Pr_0(uf))
-        _a_h = FT(a_h(uf))
-        _b_h = FT(b_h(uf))
-        return 1 + (ζ * _Pr_0 * _a_h) / (1 + _b_h * ζ)
+        _Pr_0 = FT(Pr_0(p))
+        _a_h = FT(a_h(p))
+        _b_h = FT(b_h(p))
+        return FT(1) + (ζ * _Pr_0 * _a_h) / (1 + _b_h * ζ)
     else
         # Nishizawa2018 Eq. A2 (ζ <= 0)
-        f_h = f_heat(uf, ζ)
-        return 1 / f_h
+        f_h = f_heat(p, ζ)
+        return FT(1) / FT(f_h)
     end
 end
 
-function psi(uf::Gryanik, ζ, tt::MomentumTransport)
-    FT = eltype(uf)
+function psi(p::GryanikParams, ζ, tt::MomentumTransport)
+    FT = eltype(ζ)
+    if abs(ζ) < eps(FT)
+        return FT(0)
+    end
     if ζ > 0
         # Gryanik2020 Eq. 34
-        _a_m = FT(a_m(uf))
-        _b_m = FT(b_m(uf))
+        _a_m = FT(a_m(p))
+        _b_m = FT(b_m(p))
         return -3 * (_a_m / _b_m) * ((1 + _b_m * ζ)^(FT(1 / 3)) - 1)
     else
         # Nishizawa2018 Eq. A3 (ζ <= 0)
-        f_m = f_momentum(uf, ζ)
+        f_m = f_momentum(p, ζ)
         log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
-        return log_term - 2 * atan(f_m) + FT(π) / 2
+        return FT(log_term - 2 * atan(f_m) + π / 2)
     end
 end
 
-function psi(uf::Gryanik, ζ, tt::HeatTransport)
-    FT = eltype(uf)
+function psi(p::GryanikParams, ζ, tt::HeatTransport)
+    FT = eltype(ζ)
+    if abs(ζ) < eps(FT)
+        return FT(0)
+    end
     if ζ > 0
         # Gryanik2020 Eq. 35
-        _Pr_0 = FT(Pr_0(uf))
-        _a_h = FT(a_h(uf))
-        _b_h = FT(b_h(uf))
+        _Pr_0 = FT(Pr_0(p))
+        _a_h = FT(a_h(p))
+        _b_h = FT(b_h(p))
         return -_Pr_0 * (_a_h / _b_h) * log1p(_b_h * ζ)
     else
         # Nishizawa2018 Eq. A4 (ζ <= 0)
-        f_h = f_heat(uf, ζ)
-        return 2 * log((1 + f_h) / 2)
+        f_h = f_heat(p, ζ)
+        return FT(2 * log((1 + f_h) / 2))
     end
 end
 
-function Psi(uf::Gryanik, ζ, tt::MomentumTransport)
-    FT = eltype(uf)
-    _a_m = FT(a_m(uf))
-    _b_m = FT(b_m(uf))
+function Psi(p::GryanikParams, ζ, tt::MomentumTransport)
+    FT = eltype(ζ)
+    _a_m = FT(a_m(p))
+    _b_m = FT(b_m(p))
     if ζ >= 0
-        # TODO: Add limit given default parameter combination a_m, b_m
-        # Volume-averaged form of Gryanik2020 Eq. 34
-        return 3 * (_a_m / _b_m) -
-               FT(9) * _a_m * ((_b_m * ζ + FT(1))^(FT(4 / 3)) - 1) / ζ / FT(4) /
-               _b_m^FT(2)
+        return 3 * (_a_m / _b_m) - FT(9) * _a_m * ((_b_m * ζ + FT(1))^(FT(4 / 3)) - 1) / ζ / FT(4) / _b_m^FT(2)
     else
         if abs(ζ) < eps(FT)
-            # Nishizawa2018 Eq. A13 (ζ < 0)
             return -FT(15) * ζ / FT(8)
         else
-            # Nishizawa2018 Eq. A5 (ζ < 0)
-            f_m = f_momentum(uf, ζ)
+            f_m = f_momentum(p, ζ)
             log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
             π_term = FT(π) / 2
             tan_term = 2 * atan(f_m)
             cubic_term = (1 - f_m^3) / (12 * ζ)
-            return log_term - tan_term + π_term - 1 + cubic_term
+            return FT(log_term - tan_term + π_term - 1 + cubic_term)
         end
     end
 end
 
-function Psi(uf::Gryanik, ζ, tt::HeatTransport)
-    FT = eltype(uf)
-    _a_h = FT(a_h(uf))
-    _b_h = FT(b_h(uf))
-    Pr0 = FT(Pr_0(uf))
-    # TODO Apply limits
+function Psi(p::GryanikParams, ζ, tt::HeatTransport)
+    FT = typeof(ζ)
+    _a_h = FT(a_h(p))
+    _b_h = FT(b_h(p))
+    Pr0 = FT(Pr_0(p))
     if ζ >= 0
-        # Volume-averaged form of Gryanik2020 Eq. 35
         return -_a_h / _b_h / ζ * Pr0 * ((1 / _b_h + ζ) * log1p(_b_h * ζ) - ζ)
     else
         if abs(ζ) < eps(FT)
-            # Nishizawa2018 Eq. A14 (ζ < 0)
-            return -9 * ζ / 4
+            return -FT(9) * ζ / 4
         else
-            # Nishizawa2018 Eq. A6 (ζ < 0)
-            f_h = f_heat(uf, ζ)
+            f_h = f_heat(p, ζ)
             log_term = 2 * log((1 + f_h) / 2)
-            return log_term + 2 * (1 - f_h) / (9 * ζ) - FT(1)
+            return FT(log_term + 2 * (1 - f_h) / (9 * ζ) - FT(1))
         end
     end
 end
@@ -404,6 +341,16 @@ end
 ##### Grachev
 #####
 
+"""
+    GrachevParams{FT} <: AbstractUniversalFunctionParameters{FT}
+
+Free parameters for the Grachev universal stability and stability correction
+functions.
+
+# Fields
+
+$(DSE.FIELDS)
+"""
 Base.@kwdef struct GrachevParams{FT} <: AbstractUniversalFunctionParameters{FT}
     Pr_0::FT
     a_m::FT
@@ -415,86 +362,53 @@ Base.@kwdef struct GrachevParams{FT} <: AbstractUniversalFunctionParameters{FT}
     γ::FT
 end
 
-"""
-    Grachev <: AbstractUniversalFunction{FT}
-
-# References
- - [Grachev2007](@cite)
-
-Equations in reference:
-
-    `ϕ_m`: Eq. 12
-    `ϕ_h`: Eq. 12
-    `ψ_m`: Eq. 13
-    `ψ_h`: Eq. 13
-
-# Grachev (2007) functions are applicable in the
-# stable b.l. regime (ζ >= 0). Businger (1971) functions
-# are applied in the unstable b.l. (ζ<0) regime by
-# default.
-
-# Fields
-
-$(DSE.FIELDS)
-"""
-struct Grachev{FT, PS <: GrachevParams} <: AbstractUniversalFunction{FT}
-    "Monin-Obhukov Length"
-    L::FT
-    params::PS
-end
-
-struct GrachevType <: AbstractUniversalFunctionType end
-Grachev() = GrachevType()
-
 # Nishizawa2018 Eq. A7
-f_momentum(uf::Grachev, ζ) = sqrt(sqrt(1 - 15 * ζ))
+f_momentum(::GrachevParams, ζ) = sqrt(sqrt(1 - 15 * ζ))
 
 # Nishizawa2018 Eq. A8
-f_heat(uf::Grachev, ζ) = sqrt(1 - 9 * ζ)
+f_heat(::GrachevParams, ζ) = sqrt(1 - 9 * ζ)
 
-function phi(uf::Grachev, ζ, tt::MomentumTransport)
+function phi(p::GrachevParams, ζ, tt::MomentumTransport)
+    FT = eltype(ζ)
     if ζ > 0
         # Grachev2007 Eq. 9a
-        FT = eltype(uf)
-        _a_m = FT(a_m(uf))
-        _b_m = FT(b_m(uf))
-        return 1 + _a_m * ζ * (1 + ζ)^FT(1 / 3) / (1 + _b_m * ζ)
+        _a_m = FT(a_m(p))
+        _b_m = FT(b_m(p))
+        return FT(1) + _a_m * ζ * (1 + ζ)^FT(1 / 3) / (1 + _b_m * ζ)
     else
         # Nishizawa2018 Eq. A1 (ζ < 0)
-        f_m = f_momentum(uf, ζ)
-        return 1 / f_m
+        f_m = f_momentum(p, ζ)
+        return FT(1) / FT(f_m)
     end
 end
 
-function phi(uf::Grachev, ζ, tt::HeatTransport)
+function phi(p::GrachevParams, ζ, tt::HeatTransport)
+    FT = eltype(ζ)
     if ζ > 0
         # Grachev2007 Eq. 9b
-        FT = eltype(uf)
-        _a_h = FT(a_h(uf))
-        _b_h = FT(b_h(uf))
-        _c_h = FT(c_h(uf))
-        return 1 + (_a_h * ζ + _b_h * ζ^2) / (1 + _c_h * ζ + ζ^2)
+        _a_h = FT(a_h(p))
+        _b_h = FT(b_h(p))
+        _c_h = FT(c_h(p))
+        return FT(1) + (_a_h * ζ + _b_h * ζ^2) / (1 + _c_h * ζ + ζ^2)
     else
         # Nishizawa2018 Eq. A2 (ζ < 0)
-        f_h = f_heat(uf, ζ)
-        return 1 / f_h
+        f_h = f_heat(p, ζ)
+        return FT(1) / FT(f_h)
     end
 end
 
-function psi(uf::Grachev, ζ, tt::MomentumTransport)
-    FT = eltype(uf)
+function psi(p::GrachevParams, ζ, tt::MomentumTransport)
+    FT = eltype(ζ)
+    if abs(ζ) < eps(FT)
+        return FT(0)
+    end
     if ζ > 0
         # Grachev2007 Eq. 12
-
-        _a_m = FT(a_m(uf))
-        _b_m = FT(b_m(uf))
+        _a_m = FT(a_m(p))
+        _b_m = FT(b_m(p))
         B_m = cbrt(1 / _b_m - 1)
         x = cbrt(1 + ζ)
         sqrt3 = FT(sqrt(3))
-
-        # Note: there is a mismatch between
-        # Gryanik, Eq. 26, and Grachev Eq. 12.
-        # We use the Grachev Eq. 12.
         linear_term = -3 * (_a_m / _b_m) * (x - 1)
         log_term_1 = 2 * log((x + B_m) / (1 + B_m))
         log_term_2 = log((x^2 - x * B_m + B_m^2) / (1 - B_m + B_m^2))
@@ -505,20 +419,23 @@ function psi(uf::Grachev, ζ, tt::MomentumTransport)
         return linear_term + _a_m * B_m / (2 * _b_m) * bracket_term
     else
         # Nishizawa2018 Eq. A3 (ζ < 0)
-        f_m = f_momentum(uf, ζ)
+        f_m = f_momentum(p, ζ)
         log_term = log((1 + f_m)^2 * (1 + f_m^2) / 8)
-        return log_term - 2 * atan(f_m) + FT(π) / 2
+        return FT(log_term - 2 * atan(f_m) + π / 2)
     end
 end
 
-function psi(uf::Grachev, ζ, tt::HeatTransport)
+function psi(p::GrachevParams, ζ, tt::HeatTransport)
+    FT = eltype(ζ)
+    if abs(ζ) < eps(FT)
+        return FT(0)
+    end
     if ζ > 0
         # Grachev2007 Eq. 13
-        FT = eltype(uf)
-        _Pr_0 = FT(Pr_0(uf))
-        _a_h = FT(a_h(uf))
-        _b_h = FT(b_h(uf))
-        _c_h = FT(c_h(uf))
+        _Pr_0 = FT(Pr_0(p))
+        _a_h = FT(a_h(p))
+        _b_h = FT(b_h(p))
+        _c_h = FT(c_h(p))
         B_h = sqrt(_c_h^2 - 4)
         coeff = _a_h / B_h - _b_h * _c_h / (2 * B_h)
         log_term_1 = log((2 * ζ + _c_h - B_h) / (2 * ζ + _c_h + B_h))
@@ -528,20 +445,9 @@ function psi(uf::Grachev, ζ, tt::HeatTransport)
         return -coeff * log_terms - term_2
     else
         # Nishizawa2018 Eq. A4 (ζ < 0)
-        f_h = f_heat(uf, ζ)
-        return 2 * log((1 + f_h) / 2)
+        f_h = f_heat(p, ζ)
+        return FT(2 * log((1 + f_h) / 2))
     end
 end
-
-universal_func(::BusingerType, L_MO::Real, params::BusingerParams) =
-    Businger(L_MO, params)
-universal_func(::GryanikType, L_MO::Real, params::GryanikParams) =
-    Gryanik(L_MO, params)
-universal_func(::GrachevType, L_MO::Real, params::GrachevParams) =
-    Grachev(L_MO, params)
-
-universal_func_type(::Type{T}) where {T <: BusingerParams} = BusingerType()
-universal_func_type(::Type{T}) where {T <: GryanikParams} = GryanikType()
-universal_func_type(::Type{T}) where {T <: GrachevParams} = GrachevType()
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,6 @@ FloatType = Float32
 @testset "SurfaceFluxes - Recovery Profiles" begin
     param_set = SFP.SurfaceFluxesParameters(FloatType, BusingerParams)
     thermo_params = param_set.thermo_params
-    uft = UF.universal_func_type(typeof(param_set.ufp))
     ρ_sfc = FloatType(1.15)
     ρ_in = FloatType(1.13)
     qt_sfc = FloatType(0.01)
@@ -131,7 +130,6 @@ FloatType = Float32
                 sc[jj],
                 L_MO,
                 UF.MomentumTransport(),
-                uft,
                 SF.PointValueScheme(),
             )
             Δu_fd = u_star[ii] / u_scale_fd
@@ -140,7 +138,6 @@ FloatType = Float32
                 sc[jj],
                 L_MO,
                 UF.MomentumTransport(),
-                uft,
                 SF.LayerAverageScheme(),
             )
             Δu_fv = u_star[ii] / u_scale_fv

--- a/test/test_convergence.jl
+++ b/test/test_convergence.jl
@@ -173,9 +173,6 @@ function check_over_dry_states(
                                         param_set,
                                         sfcc.L_MO,
                                         sc,
-                                        SF.Parameters.universal_func_type(
-                                            param_set,
-                                        ),
                                         sch,
                                     ),
                                 ) == sign(ΔDSEᵥ)
@@ -272,9 +269,6 @@ function check_over_moist_states(
                                         param_set,
                                         sfcc.L_MO,
                                         sc,
-                                        SF.Parameters.universal_func_type(
-                                            param_set,
-                                        ),
                                         sch,
                                     ),
                                 ) == sign(ΔDSEᵥ)

--- a/test/test_profiles.jl
+++ b/test/test_profiles.jl
@@ -10,7 +10,6 @@ const TD = Thermodynamics
 FT = Float32
 param_set = SFP.SurfaceFluxesParameters(FT, BusingerParams)
 thermo_params = param_set.thermo_params
-uft = UF.BusingerType()
 
 #! format: off
 PyCLES_output_dataset = AW.ArtifactWrapper(

--- a/test/test_universal_functions.jl
+++ b/test/test_universal_functions.jl
@@ -5,9 +5,10 @@ import QuadGK
 import SurfaceFluxes as SF
 import SurfaceFluxes.UniversalFunctions as UF
 import ClimaParams as CP
+import SurfaceFluxes.Parameters as SFP
 
 FT = Float32
-param_set = SFP.SurfaceFluxesParameters(FT, BusingerParams)
+param_set = SFP.SurfaceFluxesParameters(FT, UF.BusingerParams)
 thermo_params = param_set.thermo_params
 
 # TODO: Right now, we test these functions for
@@ -18,54 +19,42 @@ thermo_params = param_set.thermo_params
     @testset "Type stability" begin
         FT = Float32
         ζ = FT(-2):FT(0.01):FT(200)
-        for L in (-FT(10), FT(10))
-            for ufp in (
-                UF.GryanikParams(FT),
-                UF.GrachevParams(FT),
-                UF.BusingerParams(FT),
-            )
-                uft = UF.universal_func_type(typeof(ufp))
-                uf = UF.universal_func(uft, L, ufp)
-                for transport in (UF.MomentumTransport(), UF.HeatTransport())
-                    ϕ = UF.phi.(uf, ζ, transport)
-                    @test eltype(ϕ) == FT
-                    ψ = UF.psi.(uf, ζ, transport)
-                    @test eltype(ψ) == FT
-                end
+        for ufp in (
+            UF.GryanikParams(FT),
+            UF.GrachevParams(FT),
+            UF.BusingerParams(FT),
+        )
+            for transport in (UF.MomentumTransport(), UF.HeatTransport())
+                ϕ = UF.phi.(ufp, ζ, transport)
+                @test eltype(ϕ) == FT
+                ψ = UF.psi.(ufp, ζ, transport)
+                @test eltype(ψ) == FT
             end
         end
 
         # More type stability (phi/psi):
         FT = Float32
         ζ = (-FT(1), FT(0.5) * eps(FT), 2 * eps(FT))
-        for L in (-FT(10), FT(10))
-            for ufp in (
-                UF.GryanikParams(FT),
-                UF.GrachevParams(FT),
-                UF.BusingerParams(FT),
-            )
-                uft = UF.universal_func_type(typeof(ufp))
-                uf = UF.universal_func(uft, L, ufp)
-                for transport in (UF.MomentumTransport(), UF.HeatTransport())
-                    ϕ = UF.phi.(uf, ζ, transport)
-                    @test eltype(ϕ) == FT
-                    ψ = UF.psi.(uf, ζ, transport)
-                    @test eltype(ψ) == FT
-                end
+        for ufp in (
+            UF.GryanikParams(FT),
+            UF.GrachevParams(FT),
+            UF.BusingerParams(FT),
+        )
+            for transport in (UF.MomentumTransport(), UF.HeatTransport())
+                ϕ = UF.phi.(ufp, ζ, transport)
+                @test eltype(ϕ) == FT
+                ψ = UF.psi.(ufp, ζ, transport)
+                @test eltype(ψ) == FT
             end
         end
 
         # More type stability (Psi):
         FT = Float32
         ζ = (-FT(1), -FT(0.5) * eps(FT), FT(0.5) * eps(FT), 2 * eps(FT))
-        for L in (-FT(10), FT(10))
-            for ufp in (UF.GryanikParams(FT), UF.BusingerParams(FT))
-                uft = UF.universal_func_type(typeof(ufp))
-                uf = UF.universal_func(uft, L, ufp)
-                for transport in (UF.MomentumTransport(), UF.HeatTransport())
-                    Ψ = UF.Psi.(uf, ζ, transport)
-                    @test eltype(Ψ) == FT
-                end
+        for ufp in (UF.GryanikParams(FT), UF.BusingerParams(FT))
+            for transport in (UF.MomentumTransport(), UF.HeatTransport())
+                Ψ = UF.Psi.(ufp, ζ, transport)
+                @test eltype(Ψ) == FT
             end
         end
 
@@ -73,30 +62,23 @@ thermo_params = param_set.thermo_params
     @testset "Asymptotic range" begin
         FT = Float32
 
-        ϕ_h_ζ∞(uf::UF.Grachev, ζ) = 1 + FT(UF.b_h(uf))
-        ϕ_m_ζ∞(uf::UF.Grachev, ζ) =
-            FT(UF.a_m(uf)) / FT(UF.b_m(uf)) * ζ^FT(1 / 3)
+        ϕ_h_ζ∞(p::UF.GrachevParams, ζ) = 1 + FT(p.b_h)
+        ϕ_m_ζ∞(p::UF.GrachevParams, ζ) = FT(p.a_m) / FT(p.b_m) * ζ^FT(1 / 3)
 
-        ϕ_h_ζ∞(uf::UF.Gryanik, ζ) =
-            FT(1) +
-            (FT(ζ) * FT(UF.Pr_0(uf)) * FT(UF.a_h(uf))) /
-            (1 + FT(UF.b_h(uf)) * FT(ζ))
-        ϕ_m_ζ∞(uf::UF.Gryanik, ζ) =
-            FT(UF.a_m(uf) / UF.b_m(uf)^FT(2 / 3)) * ζ^FT(1 / 3)
+        ϕ_h_ζ∞(p::UF.GryanikParams, ζ) =
+            FT(1) + (FT(ζ) * FT(p.Pr_0) * FT(p.a_h)) / (1 + FT(p.b_h) * FT(ζ))
+        ϕ_m_ζ∞(p::UF.GryanikParams, ζ) =
+            FT(p.a_m / p.b_m^FT(2 / 3)) * ζ^FT(1 / 3)
 
 
-        for L in (-FT(10), FT(10))
-            for ufp in (UF.GryanikParams(FT), UF.GrachevParams(FT))
-                uft = UF.universal_func_type(typeof(ufp))
-                uf = UF.universal_func(uft, L, ufp)
-                for ζ in FT(10) .^ (4, 6, 8, 10)
-                    ϕ_h = UF.phi(uf, ζ, UF.HeatTransport())
-                    @test isapprox(ϕ_h, ϕ_h_ζ∞(uf, ζ))
-                end
-                for ζ in FT(10) .^ (8, 9, 10)
-                    ϕ_m = UF.phi(uf, ζ, UF.MomentumTransport())
-                    @test isapprox(ϕ_m, ϕ_m_ζ∞(uf, ζ))
-                end
+        for ufp in (UF.GryanikParams(FT), UF.GrachevParams(FT))
+            for ζ in FT(10) .^ (4, 6, 8, 10)
+                ϕ_h = UF.phi(ufp, ζ, UF.HeatTransport())
+                @test isapprox(ϕ_h, ϕ_h_ζ∞(ufp, ζ))
+            end
+            for ζ in FT(10) .^ (8, 9, 10)
+                ϕ_m = UF.phi(ufp, ζ, UF.MomentumTransport())
+                @test isapprox(ϕ_m, ϕ_m_ζ∞(ufp, ζ))
             end
         end
 
@@ -105,14 +87,10 @@ thermo_params = param_set.thermo_params
     # Test for Gryanik2021 Eq. 2 & 3; ensures Ψ(0) = 0
     @testset "Vanishes at Zero" begin
         FT = Float32
-        for L in (-FT(10), FT(10))
-            for ufp in (UF.GryanikParams(FT), UF.GrachevParams(FT))
-                for transport in (UF.HeatTransport(), UF.MomentumTransport())
-                    uft = UF.universal_func_type(typeof(ufp))
-                    uf = UF.universal_func(uft, L, ufp)
-                    Ψ_0 = UF.psi(uf, FT(0), transport)
-                    @test isapprox(Ψ_0, FT(0))
-                end
+        for ufp in (UF.GryanikParams(FT), UF.GrachevParams(FT))
+            for transport in (UF.HeatTransport(), UF.MomentumTransport())
+                Ψ_0 = UF.psi(ufp, FT(0), transport)
+                @test isapprox(Ψ_0, FT(0))
             end
         end
     end
@@ -132,32 +110,24 @@ thermo_params = param_set.thermo_params
                 FT(10),
                 FT(20),
             )
-            for L in FT(10) .* sign.(ζ_array)
-                for ζ in ζ_array
-                    for ufp in (
-                        UF.GryanikParams(FT),
-                        UF.GrachevParams(FT),
-                        UF.BusingerParams(FT),
-                    )
-                        uft = UF.universal_func_type(typeof(ufp))
-                        uf = UF.universal_func(uft, L, ufp)
-                        for transport in
-                            (UF.MomentumTransport(), UF.HeatTransport())
-                            # Compute ψ via numerical integration of 𝒻(ϕ(ζ))
-                            ψ_int = QuadGK.quadgk(
-                                ζ′ ->
-                                    (FT(1) - UF.phi(uf, ζ′, transport)) / ζ′,
-                                eps(FT),
-                                ζ,
-                            )
-                            # Compute ψ using function definitions of ψ(ζ)
-                            ψ = UF.psi(uf, ζ, transport)
-                            @test isapprox(
-                                ψ_int[1] - ψ,
-                                FT(0),
-                                atol = 10sqrt(eps(FT)),
-                            )
-                        end
+            for ζ in ζ_array
+                for ufp in (
+                    UF.GryanikParams(FT),
+                    UF.GrachevParams(FT),
+                    UF.BusingerParams(FT),
+                )
+                    for transport in (UF.MomentumTransport(), UF.HeatTransport())
+                        ψ_int = QuadGK.quadgk(
+                            ζ′ -> (FT(1) - UF.phi(ufp, ζ′, transport)) / ζ′,
+                            eps(FT),
+                            ζ,
+                        )
+                        ψ = UF.psi(ufp, ζ, transport)
+                        @test isapprox(
+                            ψ_int[1] - ψ,
+                            FT(0),
+                            atol = 10sqrt(eps(FT)),
+                        )
                     end
                 end
             end


### PR DESCRIPTION
- Eliminates `ModelType` and `Model` constructors. 
- Simplifies functions to dispatch on the parameters for each stability function type. 

Users may construct a param_set with, for example, `param_set = SFP.SurfaceFluxesParameters(FT, UF.BusingerParams)`. Since the Obukhov length is passed directly to the `psi, Psi`, `phi, Phi` functions, there is no need to carry another struct that contains `L_MO` and `params`. This also eliminates the need for an additional `uft` (universal function type) argument in `SurfaceFluxes.jl`
