### PR TITLE
Patch update: 0.14.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,1 +1,3 @@
+[PR 206] Updates UniversalFunctions.jl: Update functions to avoid catastrophic cancellations. Add continuity and linearisation tests + fix bug in the near-neutral limit. 
+
 [PR 186] Removes unused stability function types (Holtslag, Cheng, Beljaars). Currently supports (Businger, Grachev, Gryanik) types.  

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"


### PR DESCRIPTION
Patch release following update to UniversalFunctions in the near-neutral limit (+ additional tests checking continuity and linearisation as `zeta` tends to 0). 

Bug-fix introduced in #206 improves solutions in the near-neutral limit. (`if-else` branches to catch near-neutral stability as zeta approaches zero have now been removed).    
