### PR TITLE
(0.15.2) bump ClimaParams compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
@@ -14,7 +14,7 @@ ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 CreateParametersExt = "ClimaParams"
 
 [compat]
-ClimaParams = "1.0"
+ClimaParams = "1.0.8"
 RootSolvers = "0.4, 1.0"
 Thermodynamics = "0.15.2, 1.0"
 julia = "1.9"


### PR DESCRIPTION
The ClimaLand downgrade tests are failing [here](https://github.com/CliMA/ClimaLand.jl/actions/runs/23922544257/job/69772095886?pr=1678) with the combination of SurfaceFluxes v0.15.0 and ClimaParams v1.0.0. This is because SF v0.15.0+ uses `default_momentum_roughness_length`, which was introduced in CP v1.0.8.

The correct compat for CP in SF v0.15.0+ should be "1.0.8", not "1". This PR updates it to be correct and makes a backport release of SF 0.15.2.