### PR TITLE
ci: refresh dev-guides sync workflow from template

### DIFF
--- a/.github/workflows/update_dev_guides.yml
+++ b/.github/workflows/update_dev_guides.yml
@@ -1,16 +1,44 @@
+# Drop this file into a consumer repo at `.github/workflows/update_dev_guides.yml`.
+# It pulls the latest DeveloperGuides into `docs/dev-guides/` via `git subtree`
+# on the 1st of every month and opens a PR when there are changes.
+#
+# Prerequisites:
+#   - DeveloperGuides has already been added as a subtree at `docs/dev-guides/`:
+#       git subtree add --prefix docs/dev-guides \
+#           https://github.com/CliMA/DeveloperGuides.git main --squash
+#   - The repo's GitHub Actions are allowed to open pull requests
+#     (Settings → Actions → General → "Allow GitHub Actions to create and
+#     approve pull requests").
+#
+# Important:
+#   - PRs that touch the subtree merge metadata (the initial `subtree add` and
+#     all subsequent sync PRs) MUST be merged with a merge commit — never
+#     squash-merged. Squash-merging destroys the two-parent commit structure
+#     that `git subtree pull` relies on, causing future pulls to fail with
+#     "fatal: can't squash-merge: 'docs/dev-guides' was never added."
+#     If this has already happened, the fix is to remove and re-add the subtree:
+#       git rm -r docs/dev-guides && git commit -m "remove broken subtree"
+#       git subtree add --prefix docs/dev-guides \
+#           https://github.com/CliMA/DeveloperGuides.git main --squash
+
 name: Update Dev Guides
 on:
   schedule:
-    - cron: '0 0 1 * *' # Every 1st of the month at midnight UTC
+    # 1st of every month at 03:07 UTC. An off-peak, off-the-hour time reduces
+    # the scheduler delay that GitHub applies to popular slots like 00:00.
+    - cron: '7 3 1 * *'
   workflow_dispatch:
 
 jobs:
   update-subtree:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Full history is required for subtree pull
+          fetch-depth: 0  # Full history is required for subtree pull
 
       - name: Configure Git
         run: |
@@ -18,28 +46,52 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Pull latest dev guides
+        id: pull
         run: |
+          before=$(git rev-parse HEAD)
           git checkout -b update-dev-guides
-          # Exit 0 when there is nothing new to merge (subtree pull errors in that case).
-          git subtree pull --prefix docs/dev-guides \
-              https://github.com/CliMA/DeveloperGuides.git main --squash \
-              -m "chore: sync dev guides from central repo" || true
-
-      - name: Check for updates
-        id: check
-        run: |
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
-            echo "changes=true" >> $GITHUB_OUTPUT
+          # Capture the result so we can tell "nothing new to merge" (benign)
+          # apart from a real failure (merge conflict, broken subtree metadata,
+          # network error). A blanket `|| true` would hide those and let the
+          # workflow report success while silently never syncing again.
+          set +e
+          out=$(git subtree pull --prefix docs/dev-guides \
+                    https://github.com/CliMA/DeveloperGuides.git main --squash \
+                    -m "chore: sync dev guides from central repo" 2>&1)
+          status=$?
+          set -e
+          echo "$out"
+          if [ "$status" -ne 0 ] && ! echo "$out" | grep -qiE "up.to.date|already at commit"; then
+            echo "::error::git subtree pull failed — see log above."
+            exit 1
+          fi
+          # A new commit means the subtree advanced, i.e. there are changes.
+          if [ "$before" != "$(git rev-parse HEAD)" ]; then
+            echo "changes=true" >> "$GITHUB_OUTPUT"
           else
-            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Pull Request
-        if: steps.check.outputs.changes == 'true'
+        if: steps.pull.outputs.changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push -f origin update-dev-guides
-          gh pr create --title "chore: sync dev guides with central repo" \
-                       --body "Automated PR to sync `docs/dev-guides` with the latest changes from `CliMA/DeveloperGuides`." \
-                       --base main --head update-dev-guides || true
+          existing=$(gh pr list --head update-dev-guides --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already exists — skipping creation."
+          else
+            # Build the body with printf so the alert lands on its own lines.
+            # (A double-quoted "\n" is a literal backslash-n to gh, not a newline.)
+            printf '%s\n' \
+              'Automated PR to sync `docs/dev-guides` with the latest changes from `CliMA/DeveloperGuides`.' \
+              '' \
+              '> [!CAUTION]' \
+              '> **Merge with a merge commit, NOT with squash merge.** Squash-merging destroys the subtree metadata and breaks future syncs.' \
+              > "$RUNNER_TEMP/pr-body.md"
+            gh pr create --title "chore: sync dev guides with central repo" \
+                         --body-file "$RUNNER_TEMP/pr-body.md" \
+                         --base "${{ github.event.repository.default_branch }}" \
+                         --head update-dev-guides
+          fi


### PR DESCRIPTION
Replaces the hand-maintained `update_dev_guides.yml` with the current template from CliMA/DeveloperGuides.

This fixes a permissions bug in the workflow that prevented the monthly sync job from opening PRs correctly.