### PR TITLE
More robust solve for stability parameter in stable conditions (regula falsi instead of secant)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+[v1.1.0] More robust solve for the stability parameter ζ. The unbracketed secant
+iteration (which could take near-singular steps to |ζ| ≫ 100 in very stable conditions), is replaced by a branchless, bracketed solve, with a fixed number of residual evaluations.
+
+**Behavior changes:**
+
+- For supercritical `Ri_b` (no root within `|ζ| <= 100`), ζ now deterministically
+  saturates at the limit of the correct stability branch with `converged = false`,
+  instead of returning a clamped stray secant iterate that could lie on the wrong branch.
+- Converged roots may differ from the secant solver's at the level of the solver
+  tolerances; regression-test results are unchanged within their tolerances.
+
 [v1.0.1] Documentation audit and cleanup. Export `compute_profile_value` (previously
 documented but not exported). Fix docstring/Documenter rendering issues (a stray tab in the
 `windspeed` math block, and `[units] (...)` patterns that Documenter misparsed as links;
@@ -23,10 +34,10 @@ auto-sync workflow, and add `AGENTS.md`.
 
 [PR 230/231] Updates docs; minor bug fix; additional tests. Release of v1.0
 
-[PR 212] Refactor of SurfaceFluxes.jl: Consistently use stability parameter in all solvers and as inputs to many functions. Added functionality for wind speed dependent roughness lengths (Charnock, COARE3) and option to use functions to compute surface temperature/humidity. 
+[PR 212] Refactor of SurfaceFluxes.jl: Consistently use stability parameter in all solvers and as inputs to many functions. Added functionality for wind speed dependent roughness lengths (Charnock, COARE3) and option to use functions to compute surface temperature/humidity.
 
 [PR 211] Fixes a bug in sensible heat flux
 
-[PR 206] Updates UniversalFunctions.jl: Update functions to avoid catastrophic cancellations. Add continuity and linearisation tests + fix bug in the near-neutral limit. 
+[PR 206] Updates UniversalFunctions.jl: Update functions to avoid catastrophic cancellations. Add continuity and linearisation tests + fix bug in the near-neutral limit.
 
 [PR 186] Removes unused stability function types (Holtslag, Cheng, Beljaars). Currently supports (Businger, Grachev, Gryanik) types.  

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
@@ -15,6 +15,6 @@ CreateParametersExt = "ClimaParams"
 
 [compat]
 ClimaParams = "1.0.8"
-RootSolvers = "0.4.5, 1.0"
+RootSolvers = "1.1"
 Thermodynamics = "0.15.9, 1.0"
 julia = "1.9"

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -735,8 +735,8 @@ the returned root is sharpened by a final interpolation of the last bracket
 
 Returns `(ζ, converged)`. `converged` is `true` when a sign change was found
 and either the solver's early-exit criterion fired (tolerance-checked mode)
-or the final bracket width satisfies the tolerances; the saturated case
-reports `false`. The flag is meaningful under `forced_fixed_iters`.
+or the final bracket width satisfies the tolerances. The saturated case
+reports `false`. This flag is meaningful regardless of the `forced_fixed_iters` setting.
 """
 function solve_stability_param(
     root_function::F,
@@ -851,7 +851,7 @@ it detects the stability branch from the residual at neutral stability, brackets
 the root with log-spaced probes within the physical range `|ζ| <= ζ_max = 100`, and refines
 it with a fixed number of safeguarded regula falsi iterations. When no
 root exists in the physical range (supercritical `Ri_b`), `ζ` saturates at the
-limit of the appropriate stability branch (\pm ζ_max) and `converged = false` is reported.
+limit of the appropriate stability branch (± ζ_max) and `converged = false` is reported.
 """
 function solve_monin_obukhov(
     param_set::APS,

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -695,8 +695,8 @@ bulk Richardson number `Ri_b(0)` vanishes), so its sign indicates the stability
 branch on which a root is expected: stable (`ζ > 0`) for `f(0) <= 0`, unstable
 (`ζ < 0`) for `f(0) > 0`.
 
-For a fixed surface state, this indication is exact: `Ri_b(ζ)` is monotone with
-`sign(Ri_b) = sign(ζ)`, so the root must lie on the branch matching the sign
+For a fixed surface state, this indication is exact: `Ri_b(ζ)` is monotonic with
+`sign(Ri_b) = sign(ζ)`, so the root lies on the branch matching the sign
 of the state Richardson number. With surface-state callbacks
 (`update_T_sfc`/`update_q_vap_sfc`), however, `Ri_b_state` itself varies with
 ζ, and in transitional (near-neutral) conditions, its sign can differ between
@@ -718,17 +718,25 @@ indicated branch limit; this preserves the expected stability regime with
 (near-)minimal fluxes.
 
 # Stage 2: fixed-count refinement (`options.maxiter` evaluations)
-Safeguarded regula falsi (Illinois variant) with a bisection fallback
-refines the root. The bracket from stage 1 is preserved at every step, so
-iterates are bounded by construction. In the saturated (no-root) case, the
-refinement runs on the outermost same-sign interval, and its result is
-discarded by the final `ifelse`. When `options.forced_fixed_iters` is
-false, the loop exits early once the bracket satisfies
-`options.tol`/`options.rtol`.
+The refinement is delegated to RootSolvers' `RegulaFalsiMethod` (safeguarded
+regula falsi, Illinois variant), passing the stage-1 bracket with its
+already-evaluated endpoint residuals so that no residual evaluation is
+repeated. The bracket is preserved at every step, so iterates are bounded by
+construction. In the saturated (no-root) case, the refinement runs on the
+outermost same-sign interval (which RootSolvers rejects without iterating),
+and its result is discarded by the final `ifelse`.
 
-Returns `(ζ, converged)`. `converged` is `true` when a sign change was
-found and the final bracket width satisfies the tolerances; the saturated
-case reports `false`. The flag is meaningful under `forced_fixed_iters`.
+When `options.forced_fixed_iters` is true, `RootSolvers.NoTolerance` runs
+exactly `maxiter` iterations with no data-dependent early exit. Otherwise,
+`RootSolvers.RelativeOrAbsoluteSolutionTolerance(rtol, tol)` allows an early
+exit once the step between iterates satisfies the tolerances. In both modes,
+the returned root is sharpened by a final interpolation of the last bracket
+(`RootSolvers.TwoPointSolution`) at no extra residual cost.
+
+Returns `(ζ, converged)`. `converged` is `true` when a sign change was found
+and either the solver's early-exit criterion fired (tolerance-checked mode)
+or the final bracket width satisfies the tolerances; the saturated case
+reports `false`. The flag is meaningful under `forced_fixed_iters`.
 """
 function solve_stability_param(
     root_function::F,
@@ -771,46 +779,59 @@ function solve_stability_param(
     b = ifelse(c1, p1, ifelse(cm, m1, ifelse(c2, p2, p3)))
     fb = ifelse(c1, r1, ifelse(cm, rm1, ifelse(c2, r2, r3)))
 
-    x = b
-    lastside = 0  # +1 if `a` was retained last, -1 if `b` was (Illinois damping)
-    for _ in 1:options.maxiter
-        # Regula falsi proposal, replaced by bisection when it is not finite
-        # or not strictly inside the bracket (e.g., same-sign endpoints in the
-        # saturated case, or a flat residual with `fb == fa`)
-        x_rf = (a * fb - b * fa) / (fb - fa)
-        x_bi = (a + b) / 2
-        use_rf = isfinite(x_rf) & (min(a, b) < x_rf) & (x_rf < max(a, b))
-        x = ifelse(use_rf, x_rf, x_bi)
-        fx = root_function(x)
-
-        # Bracket update; halving the retained endpoint's residual when the
-        # same endpoint is retained twice in a row (Illinois) prevents the
-        # one-sided stalls of plain regula falsi
-        keep_a = fa * fx <= 0  # root remains in [a, x]
-        fa = ifelse(keep_a, ifelse(lastside == 1, fa / 2, fa), fx)
-        fb = ifelse(keep_a, fx, ifelse(lastside == -1, fb / 2, fb))
-        a = ifelse(keep_a, a, x)
-        b = ifelse(keep_a, x, b)
-        lastside = ifelse(keep_a, 1, -1)
-
-        # Early exit only in tolerance-checked (CPU) mode; in forced maxiter mode, 
-        # the loop trip count is identical for every point
-        if !options.forced_fixed_iters
-            width = abs(b - a)
-            (width < options.tol || width < options.rtol * abs(x)) && break
-        end
+    # Stage 2: fixed-count safeguarded refinement, delegated to RootSolvers'
+    # regula falsi (Illinois variant with a bisection fallback). The bracket
+    # endpoints are passed pre-evaluated, so no residual evaluation is repeated
+    # and the total count stays `5 + maxiter`. `TwoPointSolution` returns the
+    # final bracket state, from which the convergence flag and a sharpened root
+    # are computed.
+    sol = if options.forced_fixed_iters
+        # No data-dependent early exit: exactly `maxiter` iterations per point
+        RS.find_zero(
+            root_function,
+            RS.RegulaFalsiMethod,
+            a,
+            b,
+            fa,
+            fb,
+            RS.TwoPointSolution(),
+            RS.NoTolerance(),
+            options.maxiter,
+        )
+    else
+        # Tolerance-checked (CPU) mode: early exit on the step between iterates
+        RS.find_zero(
+            root_function,
+            RS.RegulaFalsiMethod,
+            a,
+            b,
+            fa,
+            fb,
+            RS.TwoPointSolution(),
+            RS.RelativeOrAbsoluteSolutionTolerance(options.rtol, options.tol),
+            options.maxiter,
+        )
     end
 
     # Final regula falsi interpolant of the last bracket: improves on the last
     # evaluated point at no extra residual cost (discarded, like the rest of
-    # the refinement, when the interval does not bracket a root)
-    x_last = (a * fb - b * fa) / (fb - fa)
-    use_last = isfinite(x_last) & (min(a, b) <= x_last) & (x_last <= max(a, b))
+    # the refinement, when the interval does not bracket a root). The bracket
+    # residuals may be Illinois-damped (halved), which preserves their signs
+    # and hence the interpolant's validity.
+    x = sol.root
+    x_last = (sol.x0 * sol.y1 - sol.x1 * sol.y0) / (sol.y1 - sol.y0)
+    lo = min(sol.x0, sol.x1)
+    hi = max(sol.x0, sol.x1)
+    use_last = isfinite(x_last) & (lo <= x_last) & (x_last <= hi)
     x = ifelse(use_last, x_last, x)
 
-    width = abs(b - a)
+    # Converged when a sign change was found and either the solver's early-exit
+    # criterion was met (tolerance-checked mode) or the final bracket width satisfies 
+    # the tolerances.
+    width = abs(sol.x1 - sol.x0)
     converged =
-        bracketed && (width < options.tol || width < options.rtol * abs(x))
+        bracketed &&
+        (sol.converged || width < options.tol || width < options.rtol * abs(x))
     ζ = ifelse(bracketed, x, p3)
     return ζ, converged
 end
@@ -825,12 +846,12 @@ by `options.maxiter` and `options.tol`. If `options.forced_fixed_iters` is true,
 ignores tolerance and iterates for exactly `maxiter`.
 
 The ζ-iteration is performed by the internal `solve_stability_param`, a
-fixed-evaluation-count and branchless bracketed solve suitable for GPU execution: 
-it detects the stability branch from the residual at neutral stability, brackets 
-the root with log-spaced probes within the physical range `|ζ| <= 100`, and refines 
-it with a fixed number of safeguarded regula falsi iterations. When no root exists 
-in the physical range (supercritical `Ri_b`), `ζ` saturates at the limit of the 
-appropriate stability branch and `converged = false` is reported.
+fixed-evaluation-count and branchless bracketed solve suitable for GPU execution:
+it detects the stability branch from the residual at neutral stability, brackets
+the root with log-spaced probes within the physical range `|ζ| <= 100`, and refines
+it with a fixed number of safeguarded regula falsi iterations. When no
+root exists in the physical range (supercritical `Ri_b`), `ζ` saturates at the
+limit of the appropriate stability branch and `converged = false` is reported.
 """
 function solve_monin_obukhov(
     param_set::APS,

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -848,10 +848,10 @@ ignores tolerance and iterates for exactly `maxiter`.
 The ζ-iteration is performed by the internal `solve_stability_param`, a
 fixed-evaluation-count and branchless bracketed solve suitable for GPU execution:
 it detects the stability branch from the residual at neutral stability, brackets
-the root with log-spaced probes within the physical range `|ζ| <= 100`, and refines
+the root with log-spaced probes within the physical range `|ζ| <= ζ_max = 100`, and refines
 it with a fixed number of safeguarded regula falsi iterations. When no
 root exists in the physical range (supercritical `Ri_b`), `ζ` saturates at the
-limit of the appropriate stability branch and `converged = false` is reported.
+limit of the appropriate stability branch (\pm ζ_max) and `converged = false` is reported.
 """
 function solve_monin_obukhov(
     param_set::APS,

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -682,6 +682,140 @@ function (rf::ResidualFunction)(ζ)
 end
 
 """
+    solve_stability_param(root_function, ζ_max, options)
+
+GPU-friendly solver for the stability parameter ζ. It uses a fixed number
+of residual evaluations (`options.maxiter` + 5) and no data-dependent control
+flow when `options.forced_fixed_iters` is true: every point performs identical
+work, so warps execute uniformly.
+
+# Stage 1: branch detection and bracketing (5 evaluations)
+The residual at neutral stability is `f(0) = -Ri_b_state` (the theoretical
+bulk Richardson number `Ri_b(0)` vanishes), so its sign indicates the stability
+branch on which a root is expected: stable (`ζ > 0`) for `f(0) <= 0`, unstable
+(`ζ < 0`) for `f(0) > 0`.
+
+For a fixed surface state, this indication is exact: `Ri_b(ζ)` is monotone with
+`sign(Ri_b) = sign(ζ)`, so the root must lie on the branch matching the sign
+of the state Richardson number. With surface-state callbacks
+(`update_T_sfc`/`update_q_vap_sfc`), however, `Ri_b_state` itself varies with
+ζ, and in transitional (near-neutral) conditions, its sign can differ between
+the neutral evaluation and evaluations on the branch; therefore, the root can lie 
+on the opposite branch from what `f(0)` indicates. To cover this, the residual is
+probed at `ζ = ±1` on *both* branches, and at `|ζ| = 10, ζ_max` on the
+indicated branch. The bracketing interval is selected from the sign changes in
+priority order, innermost first: `(0, ±1)` on the indicated branch, `(0, ∓1)` 
+on the opposite branch, then `(±1, ±10)` and `(±10, ±ζ_max)` on the indicated 
+branch. (For a fixed surface state, the opposite-branch interval can never bracket, 
+so this probe changes nothing in callback-free solves; an opposite-branch root 
+at `|ζ| > 1` would require the callbacks to swing the state Richardson number 
+by O(1) along the branch and is not searched for.)
+
+If no probed interval brackets a sign change, no root exists within the
+physical range (e.g., supercritical `Ri_b`, where the state is more stable
+than the universal functions can support), and the solve saturates at the
+indicated branch limit; this preserves the expected stability regime with
+(near-)minimal fluxes.
+
+# Stage 2: fixed-count refinement (`options.maxiter` evaluations)
+Safeguarded regula falsi (Illinois variant) with a bisection fallback
+refines the root. The bracket from stage 1 is preserved at every step, so
+iterates are bounded by construction. In the saturated (no-root) case, the
+refinement runs on the outermost same-sign interval, and its result is
+discarded by the final `ifelse`. When `options.forced_fixed_iters` is
+false, the loop exits early once the bracket satisfies
+`options.tol`/`options.rtol`.
+
+Returns `(ζ, converged)`. `converged` is `true` when a sign change was
+found and the final bracket width satisfies the tolerances; the saturated
+case reports `false`. The flag is meaningful under `forced_fixed_iters`.
+"""
+function solve_stability_param(
+    root_function::F,
+    ζ_max::FT,
+    options::SolverOptions,
+) where {F, FT}
+    r0 = root_function(zero(FT))
+
+    # Indicated branch: stable (ζ > 0) iff Ri_b_state = -f(0) >= 0.
+    # Exact for a fixed surface state; a heuristic when callbacks make
+    # Ri_b_state vary with ζ (see the docstring).
+    # `sgn` inherits the numeric type of the residual (e.g., Dual) so that
+    # all iterates promote consistently under automatic differentiation.
+    sgn = ifelse(r0 <= zero(r0), one(r0), -one(r0))
+
+    # Near-neutral probes on both branches, log-spaced probes outward on the
+    # indicated branch
+    p1 = sgn
+    m1 = -sgn
+    p2 = FT(10) * sgn
+    p3 = ζ_max * sgn
+    r1 = root_function(p1)
+    rm1 = root_function(m1)
+    r2 = root_function(p2)
+    r3 = root_function(p3)
+
+    # Sign-change interval, selected innermost first; the opposite-branch
+    # near-neutral interval (`cm`) covers transitional states whose callbacks
+    # put the root on the branch opposite to the `f(0)` indication. If no
+    # interval brackets (`bracketed == false`), the refinement below runs on
+    # `(p2, p3)` and its result is discarded.
+    c1 = r0 * r1 <= 0
+    cm = r0 * rm1 <= 0
+    c2 = r1 * r2 <= 0
+    c3 = r2 * r3 <= 0
+    bracketed = c1 | cm | c2 | c3
+
+    a = ifelse(c1 | cm, zero(r0), ifelse(c2, p1, p2))
+    fa = ifelse(c1 | cm, r0, ifelse(c2, r1, r2))
+    b = ifelse(c1, p1, ifelse(cm, m1, ifelse(c2, p2, p3)))
+    fb = ifelse(c1, r1, ifelse(cm, rm1, ifelse(c2, r2, r3)))
+
+    x = b
+    lastside = 0  # +1 if `a` was retained last, -1 if `b` was (Illinois damping)
+    for _ in 1:options.maxiter
+        # Regula falsi proposal, replaced by bisection when it is not finite
+        # or not strictly inside the bracket (e.g., same-sign endpoints in the
+        # saturated case, or a flat residual with `fb == fa`)
+        x_rf = (a * fb - b * fa) / (fb - fa)
+        x_bi = (a + b) / 2
+        use_rf = isfinite(x_rf) & (min(a, b) < x_rf) & (x_rf < max(a, b))
+        x = ifelse(use_rf, x_rf, x_bi)
+        fx = root_function(x)
+
+        # Bracket update; halving the retained endpoint's residual when the
+        # same endpoint is retained twice in a row (Illinois) prevents the
+        # one-sided stalls of plain regula falsi
+        keep_a = fa * fx <= 0  # root remains in [a, x]
+        fa = ifelse(keep_a, ifelse(lastside == 1, fa / 2, fa), fx)
+        fb = ifelse(keep_a, fx, ifelse(lastside == -1, fb / 2, fb))
+        a = ifelse(keep_a, a, x)
+        b = ifelse(keep_a, x, b)
+        lastside = ifelse(keep_a, 1, -1)
+
+        # Early exit only in tolerance-checked (CPU) mode; in forced maxiter mode, 
+        # the loop trip count is identical for every point
+        if !options.forced_fixed_iters
+            width = abs(b - a)
+            (width < options.tol || width < options.rtol * abs(x)) && break
+        end
+    end
+
+    # Final regula falsi interpolant of the last bracket: improves on the last
+    # evaluated point at no extra residual cost (discarded, like the rest of
+    # the refinement, when the interval does not bracket a root)
+    x_last = (a * fb - b * fa) / (fb - fa)
+    use_last = isfinite(x_last) & (min(a, b) <= x_last) & (x_last <= max(a, b))
+    x = ifelse(use_last, x_last, x)
+
+    width = abs(b - a)
+    converged =
+        bracketed && (width < options.tol || width < options.rtol * abs(x))
+    ζ = ifelse(bracketed, x, p3)
+    return ζ, converged
+end
+
+"""
     solve_monin_obukhov(param_set, inputs, scheme, options)
 
 Solves the Monin-Obukhov Similarity Theory (MOST) equations for the surface fluxes.
@@ -689,6 +823,14 @@ Iterates to find the stability parameter `ζ` that satisfies the
 surface layer profiles and surface balance equations. Convergence is controlled
 by `options.maxiter` and `options.tol`. If `options.forced_fixed_iters` is true,
 ignores tolerance and iterates for exactly `maxiter`.
+
+The ζ-iteration is performed by the internal `solve_stability_param`, a
+fixed-evaluation-count and branchless bracketed solve suitable for GPU execution: 
+it detects the stability branch from the residual at neutral stability, brackets 
+the root with log-spaced probes within the physical range `|ζ| <= 100`, and refines 
+it with a fixed number of safeguarded regula falsi iterations. When no root exists 
+in the physical range (supercritical `Ri_b`), `ζ` saturates at the limit of the 
+appropriate stability branch and `converged = false` is reported.
 """
 function solve_monin_obukhov(
     param_set::APS,
@@ -710,29 +852,13 @@ function solve_monin_obukhov(
         thermo_params,
     )
 
-    # Use SecantMethod with initial guesses spanning neutral stability
-    # (it has faster convergence than Brent's method with wide brackets)
-    ζ_init_unstable = FT(-1)
-    ζ_init_stable = FT(1)
-
-    sol = RS.find_zero(
-        root_function,
-        RS.SecantMethod(ζ_init_unstable, ζ_init_stable),
-        RS.CompactSolution(),
-        RS.RelativeOrAbsoluteSolutionTolerance(
-            options.forced_fixed_iters ? FT(0) : options.rtol,
-            options.forced_fixed_iters ? FT(0) : options.tol,
-        ),
-        options.maxiter,
-    )
-
-    # Clamp ζ to physical limits.
-    # For supercritical Ri_b (e.g., very stable stratification), the solver
-    # may not converge since no finite solution exists (e.g., for Businger profiles).
-    ζ_min = FT(-100)
+    # Physical limit for |ζ|. For supercritical Ri_b (e.g., very stable
+    # stratification), no solution exists within this limit (e.g., for
+    # Businger profiles, whose Ri_b(ζ) saturates at a critical value), and the
+    # solve saturates at the limit of the appropriate stability branch.
     ζ_max = FT(100)
-    ζ_final = clamp(sol.root, ζ_min, ζ_max)
-    converged = sol.converged
+
+    ζ_final, converged = solve_stability_param(root_function, ζ_max, options)
 
     # Finalize state
     # 1. Compute u_star and roughness

--- a/src/types.jl
+++ b/src/types.jl
@@ -120,10 +120,15 @@ end
 Options for the Monin-Obukhov similarity theory solver.
 
 # Fields
-- `tol`: Absolute tolerance on the change in the stability parameter for determining convergence.
-- `rtol`: Relative tolerance on the change in the stability parameter for determining convergence.
-- `maxiter`: Maximum number of iterations.
-- `forced_fixed_iters`: If true, disables the tolerance check and forces the solver to run for exactly `maxiter` iterations (or until machine precision is reached/bypassed). Default is `true`.
+- `tol`: Absolute tolerance on the bracket width of the stability parameter for determining convergence.
+- `rtol`: Relative tolerance on the bracket width of the stability parameter for determining convergence.
+- `maxiter`: Number of bracket-refinement iterations. The ζ-solve performs
+  `5 + maxiter` residual evaluations in total (branch detection + bracketing
+  probes + refinement); see the internal `solve_stability_param`.
+- `forced_fixed_iters`: If true (default), disables the early tolerance exit and runs
+  exactly `maxiter` refinement iterations, so every point performs identical work
+  (uniform control flow on GPUs). The `converged` flag is still evaluated from the
+  final bracket width and the tolerances.
 """
 Base.@kwdef struct SolverOptions{FT}
     tol::FT = FT(1e-2)

--- a/src/types.jl
+++ b/src/types.jl
@@ -120,15 +120,17 @@ end
 Options for the Monin-Obukhov similarity theory solver.
 
 # Fields
-- `tol`: Absolute tolerance on the bracket width of the stability parameter for determining convergence.
-- `rtol`: Relative tolerance on the bracket width of the stability parameter for determining convergence.
+- `tol`: Absolute tolerance on the stability parameter: the `converged` flag requires the
+  final bracket width to satisfy it, and in tolerance-checked mode it also bounds the step
+  between iterates for the early exit.
+- `rtol`: Relative tolerance on the stability parameter, used analogously to `tol`.
 - `maxiter`: Number of bracket-refinement iterations. The ζ-solve performs
   `5 + maxiter` residual evaluations in total (branch detection + bracketing
   probes + refinement); see the internal `solve_stability_param`.
 - `forced_fixed_iters`: If true (default), disables the early tolerance exit and runs
-  exactly `maxiter` refinement iterations, so every point performs identical work
-  (uniform control flow on GPUs). The `converged` flag is still evaluated from the
-  final bracket width and the tolerances.
+  exactly `maxiter` refinement iterations (via `RootSolvers.NoTolerance`), so every point
+  performs identical work (uniform control flow on GPUs). The `converged` flag is still
+  evaluated from the final bracket width and the tolerances.
 """
 Base.@kwdef struct SolverOptions{FT}
     tol::FT = FT(1e-2)

--- a/test/test_supercritical_stability.jl
+++ b/test/test_supercritical_stability.jl
@@ -15,6 +15,7 @@
 module TestSupercriticalStability
 
 using Test
+using ForwardDiff
 import SurfaceFluxes as SF
 import SurfaceFluxes.UniversalFunctions as UF
 import SurfaceFluxes.Parameters as SFP
@@ -371,6 +372,80 @@ import ClimaParams as CP
 
         # At least the first transition should show a genuine decrease
         @test results[1].Cd > results[3].Cd
+    end
+    @testset "AD Compatibility - Supercritical and Callbacks" begin
+        # 1. Supercritical AD check
+        function compute_shf_supercritical(T_sfc_val)
+            result = SF.surface_fluxes(
+                param_set,
+                FT(300), FT(0.005), FT(0), FT(0), FT(1.2),
+                T_sfc_val, FT(0.005),
+                FT(0), FT(10), FT(0),
+                (FT(1), FT(0)), (FT(0), FT(0)),
+                nothing,
+                config,
+                SF.PointValueScheme(),
+                opts,
+            )
+            return result.shf
+        end
+
+        # T_sfc = 280 K is heavily supercritical for T_int = 300, u = 1 m/s
+        dSHF_dT_ad = ForwardDiff.derivative(compute_shf_supercritical, FT(280))
+        ϵ = FT(1e-4)
+        dSHF_dT_fd =
+            (
+                compute_shf_supercritical(FT(280) + ϵ) -
+                compute_shf_supercritical(FT(280) - ϵ)
+            ) / (2ϵ)
+        @test isapprox(dSHF_dT_ad, dSHF_dT_fd, rtol = ϵ, atol = FT(1e-4))
+
+        # 2. Opposite branch callbacks AD check
+        T_int_o = FT(295)
+        q_o = FT(0.005)
+        ρ_o = FT(1.15)
+        Δz_o = FT(10)
+        grav = SFP.grav(param_set)
+        cp_d = SFP.cp_d(param_set)
+        T_neutral = T_int_o + grav * Δz_o / cp_d
+
+        function update_T_sfc_flip(ζ, param_set, thermo_params, inputs,
+            scheme, u_star, z0m, z0h)
+            return ζ >= 0 ? T_neutral - FT(0.1) - 3 * ζ / (1 + ζ) :
+                   T_neutral - FT(0.1) + 5 * (-ζ) / (1 - ζ)
+        end
+
+        config_o = SF.SurfaceFluxConfig(
+            SF.ConstantRoughnessParams(FT(0.01), FT(0.001)),
+            SF.ConstantGustinessSpec(FT(1)),
+        )
+
+        function compute_shf_callbacks(T_sfc_val)
+            result = SF.surface_fluxes(
+                param_set,
+                T_int_o, q_o, FT(0), FT(0), ρ_o,
+                T_sfc_val, q_o,
+                FT(0), Δz_o, FT(0),
+                (FT(0.5), FT(0)), (FT(0), FT(0)),
+                nothing,
+                config_o,
+                SF.PointValueScheme(),
+                opts,
+                nothing,
+                update_T_sfc_flip,
+                nothing,
+            )
+            return result.shf
+        end
+
+        # Base T_sfc near neutral
+        dSHF_dT_ad_cb = ForwardDiff.derivative(compute_shf_callbacks, T_neutral - FT(0.1))
+        dSHF_dT_fd_cb =
+            (
+                compute_shf_callbacks(T_neutral - FT(0.1) + ϵ) -
+                compute_shf_callbacks(T_neutral - FT(0.1) - ϵ)
+            ) / (2ϵ)
+        @test isapprox(dSHF_dT_ad_cb, dSHF_dT_fd_cb, rtol = ϵ, atol = FT(1e-4))
     end
 end
 

--- a/test/test_supercritical_stability.jl
+++ b/test/test_supercritical_stability.jl
@@ -136,6 +136,213 @@ import ClimaParams as CP
         @test result.shf < 0  # Downward heat flux (cold surface)
     end
 
+    @testset "Supercritical stability with coupled canopy callbacks" begin
+        # Regression test for solver robustness with T_sfc/q_vap_sfc callbacks
+        # (ClimaLand canopy coupling). With a strong inversion (~10 K over 10 m)
+        # and weak wind, Ri_b is supercritical. The callbacks additionally make
+        # the state Ri_b *increase* with ζ (colder canopy-weighted T_sfc as
+        # u_star drops), so the residual decreases toward a negative plateau.
+        T_int_c = FT(294.673095703125)
+        q_tot_int_c = FT(0.009545918211858238)
+        ρ_int_c = FT(1.157759649975361)
+        T_canopy = FT(284.6341213016535)
+        q_canopy = FT(0.008910620278696149)
+        Δz_c = FT(10)
+        d_c = FT(0.0573)
+        u_int_c = (FT(1.3673065900802612), FT(0))
+        AI = FT(3.1223678081630233)
+        leaf_Cd = FT(0.0726)
+        g_stomata = FT(5.848035071201371e-6)
+
+        config_c = SF.SurfaceFluxConfig(
+            SF.ConstantRoughnessParams(FT(0.359), FT(0.0544)),
+            SF.ConstantGustinessSpec(FT(1)),
+        )
+
+        # Canopy energy balance: T_sfc between T_int and T_canopy, weighted by
+        # the ratio of canopy conductance g_land to aerodynamic conductance g_h
+        function update_T_sfc(ζ, param_set, thermo_params, inputs, scheme,
+            u_star, z0m, z0h)
+            Φ_sfc = SF.surface_geopotential(inputs)
+            Φ_int = SF.interior_geopotential(param_set, inputs)
+            g_h = SF.heat_conductance(param_set, ζ, u_star, inputs, z0m, z0h, scheme)
+            g_land = leaf_Cd * u_star * AI
+            cp_d = SFP.cp_d(param_set)
+            r = g_land / g_h
+            return (inputs.T_int + inputs.T_sfc_guess * r + (Φ_int - Φ_sfc) / cp_d) /
+                   (1 + r)
+        end
+
+        # Canopy moisture balance with stomatal + leaf boundary-layer conductance
+        function update_q_vap_sfc(ζ, param_set, thermo_params, inputs, scheme,
+            T_sfc, u_star, z0m, z0h)
+            g_leaf = leaf_Cd * u_star * AI
+            g_land = g_stomata * g_leaf / (g_leaf + g_stomata)
+            g_h = SF.heat_conductance(param_set, ζ, u_star, inputs, z0m, z0h, scheme)
+            q_vap_int = inputs.q_tot_int - inputs.q_liq_int - inputs.q_ice_int
+            r = g_land / g_h
+            return (r * inputs.q_vap_sfc_guess + q_vap_int) / (1 + r)
+        end
+
+        for uf_type in (UF.BusingerParams, UF.GryanikParams),
+            solver_opts in (
+                nothing,  # default: forced fixed iterations (GPU mode)
+                SF.SolverOptions{FT}(
+                    tol = FT(1e-4),
+                    rtol = FT(1e-4),
+                    maxiter = 30,
+                    forced_fixed_iters = false,
+                ),
+            )
+
+            ps = SFP.SurfaceFluxesParameters(FT, uf_type)
+            result = SF.surface_fluxes(
+                ps,
+                T_int_c, q_tot_int_c, FT(0), FT(0), ρ_int_c,
+                T_canopy, q_canopy,
+                FT(0), Δz_c, d_c,
+                u_int_c, (FT(0), FT(0)),
+                nothing,
+                config_c,
+                SF.PointValueScheme(),
+                solver_opts,
+                nothing,
+                update_T_sfc,
+                update_q_vap_sfc,
+            )
+
+            @test isfinite(result.shf)
+            @test isfinite(result.lhf)
+            @test isfinite(result.ustar)
+            @test isfinite(result.ζ)
+
+            # The stability regime must be preserved: strongly stable state
+            # must not come back as unstable (ζ < 0). This case is
+            # supercritical for both UFs, so the solve must deterministically
+            # saturate at the stable branch limit in both solver modes.
+            @test result.ζ == FT(100)
+            @test result.converged == false
+
+            # Near-decoupled surface: weak downward heat flux, weak friction
+            @test result.shf < 0
+            @test abs(result.shf) < FT(5)
+            @test FT(0) < result.ustar < FT(0.05)
+
+            # Final surface state must lie between the canopy and air states
+            @test T_canopy <= result.T_sfc <= T_int_c
+        end
+
+        # With the tolerance-checked solver, the no-root (supercritical) case
+        # must deterministically saturate at the stable limit
+        ps_b = SFP.SurfaceFluxesParameters(FT, UF.BusingerParams)
+        result_sat = SF.surface_fluxes(
+            ps_b,
+            T_int_c, q_tot_int_c, FT(0), FT(0), ρ_int_c,
+            T_canopy, q_canopy,
+            FT(0), Δz_c, d_c,
+            u_int_c, (FT(0), FT(0)),
+            nothing,
+            config_c,
+            SF.PointValueScheme(),
+            SF.SolverOptions{FT}(
+                tol = FT(1e-4),
+                rtol = FT(1e-4),
+                maxiter = 30,
+                forced_fixed_iters = false,
+            ),
+            nothing,
+            update_T_sfc,
+            update_q_vap_sfc,
+        )
+        @test result_sat.ζ == FT(100)
+        @test result_sat.converged == false
+    end
+
+    @testset "Opposite-branch root with surface-state callbacks" begin
+        # With callbacks, Ri_b_state varies with ζ, so the sign of the
+        # residual at neutral, f(0) = -Ri_b_state(0), is only a heuristic
+        # for the branch containing the root. This synthetic callback makes
+        # the state weakly stable when evaluated at ζ >= 0 (f(0) < 0 =>
+        # stable branch indicated, and supercritical there, so no stable
+        # root) but strongly unstable when evaluated at ζ < 0, putting the
+        # only root on the unstable branch. The ζ = ∓1 opposite-branch probe
+        # in solve_stability_param must find it; committing to the indicated
+        # branch alone would saturate at ζ = +100 with near-zero fluxes.
+        T_int_o = FT(295)
+        q_o = FT(0.005)
+        ρ_o = FT(1.15)
+        Δz_o = FT(10)
+        grav = SFP.grav(param_set)
+        cp_d = SFP.cp_d(param_set)
+        T_neutral = T_int_o + grav * Δz_o / cp_d
+
+        function update_T_sfc_flip(ζ, param_set, thermo_params, inputs,
+            scheme, u_star, z0m, z0h)
+            # Weakly stable for ζ >= 0 (growing supercritically), strongly
+            # unstable for ζ < 0
+            return ζ >= 0 ? T_neutral - FT(0.1) - 3 * ζ / (1 + ζ) :
+                   T_neutral - FT(0.1) + 5 * (-ζ) / (1 - ζ)
+        end
+
+        config_o = SF.SurfaceFluxConfig(
+            SF.ConstantRoughnessParams(FT(0.01), FT(0.001)),
+            SF.ConstantGustinessSpec(FT(1)),
+        )
+
+        for solver_opts in (
+            nothing,  # default: forced fixed iterations (GPU mode)
+            SF.SolverOptions{FT}(
+                tol = FT(1e-4),
+                rtol = FT(1e-4),
+                maxiter = 30,
+                forced_fixed_iters = false,
+            ),
+        )
+            result = SF.surface_fluxes(
+                param_set,
+                T_int_o, q_o, FT(0), FT(0), ρ_o,
+                T_neutral - FT(0.1), q_o,
+                FT(0), Δz_o, FT(0),
+                (FT(0.5), FT(0)), (FT(0), FT(0)),
+                nothing,
+                config_o,
+                SF.PointValueScheme(),
+                solver_opts,
+                nothing,
+                update_T_sfc_flip,
+                nothing,
+            )
+
+            # Root found on the unstable branch, near neutral
+            @test FT(-1) < result.ζ < FT(0)
+            # Warm surface: upward sensible heat flux
+            @test result.shf > 0
+            @test isfinite(result.ustar) && result.ustar > 0
+        end
+
+        # In tolerance-checked mode the bracketed root must report converged
+        result_conv = SF.surface_fluxes(
+            param_set,
+            T_int_o, q_o, FT(0), FT(0), ρ_o,
+            T_neutral - FT(0.1), q_o,
+            FT(0), Δz_o, FT(0),
+            (FT(0.5), FT(0)), (FT(0), FT(0)),
+            nothing,
+            config_o,
+            SF.PointValueScheme(),
+            SF.SolverOptions{FT}(
+                tol = FT(1e-4),
+                rtol = FT(1e-4),
+                maxiter = 30,
+                forced_fixed_iters = false,
+            ),
+            nothing,
+            update_T_sfc_flip,
+            nothing,
+        )
+        @test result_conv.converged == true
+    end
+
     @testset "Fluxes decrease with increasing stability" begin
         # More strongly stable conditions should have smaller magnitude fluxes.
         # When ζ hits the upper clamp (100), Cd saturates to a constant value.


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

* Replaces secant method for solving for stability parameter with bracketing method (regula falsi), to guarantee correct limits in very stable situations 
* Updates to RootSolvers 1.1, with improved handling of residual inputs and forced iteration numbers
* Reliably and accurately compute stability parameter in stable situations as long as T_sfc is fixed; also empirically work with "reasonable" T_sfc functions (but does not have guarantees for arbitrary T_sfc functions)

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->
