### PR TITLE
Support T_sfc_guess updates between solver iterations.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,17 @@
-AD compatibility tests now cover Enzyme (forward and reverse) via
+- AD compatibility tests now cover Enzyme (forward and reverse) via
 DifferentiationInterface, in addition to ForwardDiff. Derivatives of sensible heat
 flux with respect to surface temperature are checked against central finite differences
 across stable, near-neutral, and unstable regimes.
+
+**Behavior changes:**
+
+- When `update_T_sfc` or `update_q_vap_sfc` callbacks are supplied, the solver is routed through 
+  an `solve_stability_param_cb` function. On each solver call the `inputs`
+  argument received by the callback will have `inputs.T_sfc_guess` and
+  `inputs.q_vap_sfc_guess` set to the **previous iteration's returned values**,
+  not the original guesses passed by the caller. Callbacks that read these fields
+  as a starting point for their physics should be aware that the values evolve
+  across solver iterations.
 
 [v1.1.0] More robust solve for the stability parameter ζ. The unbracketed secant
 iteration (which could take near-singular steps to |ζ| ≫ 100 in very stable conditions), is replaced by a branchless, bracketed solve, with a fixed number of residual evaluations.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SurfaceFluxes"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 authors = ["Climate Modeling Alliance"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"

--- a/docs/src/PrescribedConditions.md
+++ b/docs/src/PrescribedConditions.md
@@ -109,4 +109,14 @@ Available callbacks:
 
 If a callback returns a non-`Real` value (or is `nothing`), the initial guess from the inputs is used instead.
 
+!!! warning "Evolving guesses across solver iterations"
+    When either callback is supplied, the solver uses an `solve_stability_param_cb` function
+    that advances the surface state across ζ iterations. On each call the `inputs`
+    argument received by the callback will have `inputs.T_sfc_guess` and
+    `inputs.q_vap_sfc_guess` set to the **previous iteration's returned values**,
+    not the original guesses passed by the caller. Callbacks that read these fields
+    as a starting point for their own physics should be aware that the values change
+    with each solver iteration — this is intentional, so that Newton-style surface
+    updates linearize around the most recent iterate rather than the stale initial guess.
+
 This mechanism ensures that the final fluxes and surface state are in equilibrium with respect to the surface energy/moisture balance.

--- a/src/SurfaceFluxes.jl
+++ b/src/SurfaceFluxes.jl
@@ -122,6 +122,24 @@ Evaluate a surface state callback, returning `default` if callback is nothing or
 end
 
 """
+    with_sfc_guesses(inputs, T_sfc_guess, q_vap_sfc_guess)
+
+Return a copy of `inputs` with updated surface temperature and humidity guesses.
+Used to advance Newton iterates during the MOST solve without mutating the original inputs.
+"""
+@inline with_sfc_guesses(inputs, T_sfc_guess, q_vap_sfc_guess) =
+    (; inputs..., T_sfc_guess, q_vap_sfc_guess)
+
+@inline safe_T_sfc_guess(inputs) =
+    inputs.T_sfc_guess === nothing ? inputs.T_int : inputs.T_sfc_guess
+
+@inline safe_q_vap_sfc_guess(inputs) =
+    inputs.q_vap_sfc_guess === nothing ? inputs.q_tot_int : inputs.q_vap_sfc_guess
+
+@inline has_sfc_callbacks(inputs) =
+    inputs.update_T_sfc !== nothing || inputs.update_q_vap_sfc !== nothing
+
+"""
     surface_fluxes(
         param_set::APS,
         T_int,
@@ -586,24 +604,16 @@ given the exchange coefficients and surface state.
     return (shf, lhf, E, ρτxz, ρτyz)
 end
 
-struct ResidualFunction{PS, I, UF, TP, SCH} <: Function
-    param_set::PS
-    inputs::I
-    scheme::SCH
-    uf_params::UF
-    thermo_params::TP
-end
-
-function (rf::ResidualFunction)(ζ)
-    FT = eltype(rf.param_set)
-
-    # Unpack parameters that do not change over iterations
-    param_set = rf.param_set
-    inputs = rf.inputs
-    scheme = rf.scheme
-    uf_params = rf.uf_params
-    thermo_params = rf.thermo_params
-
+function evaluate_most_residual(
+    param_set,
+    inputs,
+    scheme,
+    uf_params,
+    thermo_params,
+    ζ,
+    T_sfc_guess_safe,
+    q_vap_sfc_guess_safe,
+)
     # 1. Compute u_star and roughness lengths, iteratively if they are mutually dependent
     u_star, z0m, z0h = compute_ustar_and_roughness(
         param_set,
@@ -612,15 +622,8 @@ function (rf::ResidualFunction)(ζ)
         scheme,
     )
 
+    # 2. Update T_sfc and q_vap_sfc via callbacks or use current guesses
     # Ensure type stability for default values (strip Union{Nothing, FT})
-    # If guess is nothing, use interior values as safe dummy defaults
-    T_sfc_guess_safe =
-        inputs.T_sfc_guess === nothing ? inputs.T_int : inputs.T_sfc_guess
-    q_vap_sfc_guess_safe =
-        inputs.q_vap_sfc_guess === nothing ? inputs.q_tot_int :
-        inputs.q_vap_sfc_guess
-
-    # 2. Update T_sfc and q_vap_sfc via callbacks or use inputs
     T_sfc_new = eval_callback(
         inputs.update_T_sfc,
         T_sfc_guess_safe,
@@ -661,7 +664,6 @@ function (rf::ResidualFunction)(ζ)
     )
 
     # 4. Compute gustiness and ΔU
-    # Use the buoyancy flux derived from the current ζ and ustar to calculate gustiness
     current_ΔU = windspeed(param_set, ζ, u_star, inputs)
 
     # 5. Calculate state bulk Richardson number
@@ -678,7 +680,30 @@ function (rf::ResidualFunction)(ζ)
     Δz_eff = effective_height(inputs)
     Rib_theory = UF.bulk_richardson_number(uf_params, Δz_eff, ζ, z0m, z0h, scheme)
 
-    return Rib_theory - Rib_state
+    return Rib_theory - Rib_state, T_sfc_new, q_vap_sfc_new
+end
+
+struct ResidualFunction{PS, I, UF, TP, SCH} <: Function
+    param_set::PS
+    inputs::I
+    scheme::SCH
+    uf_params::UF
+    thermo_params::TP
+end
+
+function (rf::ResidualFunction)(ζ)
+    inputs = rf.inputs
+    residual, _, _ = evaluate_most_residual(
+        rf.param_set,
+        inputs,
+        rf.scheme,
+        rf.uf_params,
+        rf.thermo_params,
+        ζ,
+        safe_T_sfc_guess(inputs),
+        safe_q_vap_sfc_guess(inputs),
+    )
+    return residual
 end
 
 """
@@ -837,6 +862,126 @@ function solve_stability_param(
 end
 
 """
+    solve_stability_param_cb(
+        param_set, inputs, scheme, uf_params, thermo_params,
+        ζ_max, options, T_sfc_init, q_vap_init,
+    )
+
+Variant of [`solve_stability_param`](@ref) for the surface-state-callback
+path. Performs identical bracketing and Illinois regula falsi refinement, but carries
+`T_sfc_iter` and `q_vap_iter` as stack-allocated locals between residual
+evaluations, so all values remain `isbits` and the function compiles inside GPU kernels.
+
+Returns `(ζ, converged, T_sfc_final, q_vap_final)`. The returned surface-state
+values are from the last residual evaluation and are used to finalize the surface
+fluxes after the solve.
+"""
+function solve_stability_param_cb(
+    param_set,
+    inputs,
+    scheme,
+    uf_params,
+    thermo_params,
+    ζ_max::FT,
+    options::SolverOptions,
+    T_sfc_init,
+    q_vap_init,
+) where {FT}
+    # Evaluate residual at ζ, advancing the surface-state guess as a plain local
+    function eval_cb(ζ, T_sfc, q_vap)
+        evaluate_most_residual(
+            param_set,
+            with_sfc_guesses(inputs, T_sfc, q_vap),
+            scheme, uf_params, thermo_params,
+            ζ, T_sfc, q_vap,
+        )
+    end
+
+    # Stage 1: branch detection and bracketing — same 5 probes as solve_stability_param,
+    # with the surface state threaded sequentially through each evaluation
+    r0, T_curr, q_curr = eval_cb(zero(FT), T_sfc_init, q_vap_init)
+    sgn = ifelse(r0 <= zero(r0), one(r0), -one(r0))
+
+    p1 = sgn;
+    m1 = -sgn
+    p2 = FT(10) * sgn;
+    p3 = ζ_max * sgn
+
+    r1, T_curr, q_curr = eval_cb(p1, T_curr, q_curr)
+    rm1, T_curr, q_curr = eval_cb(m1, T_curr, q_curr)
+    r2, T_curr, q_curr = eval_cb(p2, T_curr, q_curr)
+    r3, T_curr, q_curr = eval_cb(p3, T_curr, q_curr)
+
+    # Save the surface state after the last bracketing probe. In the no-root
+    # (supercritical) case the refinement loop runs on a same-sign interval and
+    # its state advances are discarded; we return this saved state instead.
+    T_p3 = T_curr
+    q_p3 = q_curr
+
+    c1 = r0 * r1 <= 0
+    cm = r0 * rm1 <= 0
+    c2 = r1 * r2 <= 0
+    c3 = r2 * r3 <= 0
+    bracketed = c1 | cm | c2 | c3
+
+    a = ifelse(c1 | cm, zero(r0), ifelse(c2, p1, p2))
+    fa = ifelse(c1 | cm, r0, ifelse(c2, r1, r2))
+    b = ifelse(c1, p1, ifelse(cm, m1, ifelse(c2, p2, p3)))
+    fb = ifelse(c1, r1, ifelse(cm, rm1, ifelse(c2, r2, r3)))
+
+    # Stage 2: Illinois regula falsi, inlined so T_curr/q_curr thread as plain locals.
+    # Matches RootSolvers' _find_zero_bracketed/_regula_falsi_y_update exactly:
+    # conditional halving (only when the same endpoint was retained on the previous step)
+    # and a bisection fallback when the bracket is nearly flat.
+    c = a
+    lastside = 0  # +1 = b moved last, -1 = a moved last
+    for _ in 1:options.maxiter
+        # Regula falsi interpolant with bisection fallback for flat brackets
+        c = ifelse(
+            abs(fb - fa) < 100 * eps(fb),
+            a + (b - a) / 2,
+            (a * fb - b * fa) / (fb - fa),
+        )
+        fc, T_curr, q_curr = eval_cb(c, T_curr, q_curr)
+
+        # is_neg: root is between a and c → b moves to c
+        is_neg = fc * fa < zero(fc)  # strict, matching RootSolvers
+
+        # Illinois y-update: halve only when same endpoint retained twice in a row
+        fa_next = ifelse(is_neg, ifelse(lastside == +1, fa / 2, fa), fc)
+        fb_next = ifelse(is_neg, fc, ifelse(lastside == -1, fb / 2, fb))
+        a = ifelse(is_neg, a, c)
+        b = ifelse(is_neg, c, b)
+        fa = fa_next
+        fb = fb_next
+        lastside = ifelse(is_neg, +1, -1)
+
+        if !options.forced_fixed_iters
+            width = abs(b - a)
+            (width < options.tol || width < options.rtol * abs(c)) && break
+        end
+    end
+
+    # Final regula falsi interpolant of the last bracket: free improvement over last c
+    x_last = (a * fb - b * fa) / (fb - fa)
+    lo = min(a, b)
+    hi = max(a, b)
+    use_last = isfinite(x_last) & (lo <= x_last) & (x_last <= hi)
+    x = ifelse(use_last, x_last, c)
+
+    width = abs(b - a)
+    converged =
+        bracketed &&
+        (width < options.tol || width < options.rtol * abs(x))
+    ζ = ifelse(bracketed, x, p3)
+    # In the no-root case, discard the refinement loop's state (computed on a
+    # same-sign interval) and return the state from the saturated probe at p3.
+    T_final = ifelse(bracketed, T_curr, T_p3)
+    q_final = ifelse(bracketed, q_curr, q_p3)
+    return ζ, converged, T_final, q_final
+end
+
+"""
     solve_monin_obukhov(param_set, inputs, scheme, options)
 
 Solves the Monin-Obukhov Similarity Theory (MOST) equations for the surface fluxes.
@@ -865,38 +1010,48 @@ function solve_monin_obukhov(
     uf_params = SFP.uf_params(param_set)
     thermo_params = SFP.thermodynamics_params(param_set)
 
-    root_function = ResidualFunction(
-        param_set,
-        inputs,
-        scheme,
-        uf_params,
-        thermo_params,
-    )
-
     # Physical limit for |ζ|. For supercritical Ri_b (e.g., very stable
     # stratification), no solution exists within this limit (e.g., for
     # Businger profiles, whose Ri_b(ζ) saturates at a critical value), and the
     # solve saturates at the limit of the appropriate stability branch.
     ζ_max = FT(100)
 
-    ζ_final, converged = solve_stability_param(root_function, ζ_max, options)
+    if has_sfc_callbacks(inputs)
+        # Callback path: inline Illinois loop carries T_sfc/q_vap as stack locals
+        # so all values remain isbits and the solve compiles inside GPU kernels.
+        ζ_final, converged, T_sfc_guess_safe, q_vap_sfc_guess_safe =
+            solve_stability_param_cb(
+                param_set,
+                inputs,
+                scheme,
+                uf_params,
+                thermo_params,
+                ζ_max,
+                options,
+                safe_T_sfc_guess(inputs),
+                safe_q_vap_sfc_guess(inputs),
+            )
+        inputs = with_sfc_guesses(inputs, T_sfc_guess_safe, q_vap_sfc_guess_safe)
+    else
+        root_function = ResidualFunction(
+            param_set,
+            inputs,
+            scheme,
+            uf_params,
+            thermo_params,
+        )
+        ζ_final, converged = solve_stability_param(root_function, ζ_max, options)
+        T_sfc_guess_safe = safe_T_sfc_guess(inputs)
+        q_vap_sfc_guess_safe = safe_q_vap_sfc_guess(inputs)
+    end
 
-    # Finalize state
-    # 1. Compute u_star and roughness
-    # Consistent with ζ_final
+    # 1. Compute u_star and roughness consistent with ζ_final
     u_star_curr, z0m, z0h = compute_ustar_and_roughness(
         param_set,
         ζ_final,
         inputs,
         scheme,
     )
-
-    # Ensure type stability for default values (strip Union{Nothing, FT})
-    T_sfc_guess_safe =
-        inputs.T_sfc_guess === nothing ? inputs.T_int : inputs.T_sfc_guess
-    q_vap_sfc_guess_safe =
-        inputs.q_vap_sfc_guess === nothing ? inputs.q_tot_int :
-        inputs.q_vap_sfc_guess
 
     T_sfc_val = eval_callback(
         inputs.update_T_sfc,

--- a/test/test_land_use_cases.jl
+++ b/test/test_land_use_cases.jl
@@ -3,6 +3,7 @@
 # Tests specific coupled surface schemes:
 # 1. Beta Model: Parameterizes moisture availability factor (β)
 # 2. Canopy Model: Solves coupled energy/moisture balance with stomatal resistance
+# 3. Solving for snow surface temperature that satisfies a flux balance
 using SurfaceFluxes
 using SurfaceFluxes.UniversalFunctions: BusingerParams
 using SurfaceFluxes: Parameters
@@ -28,13 +29,13 @@ u_sfc = (FT(0), FT(0))
 @testset "Beta Model for Evaporation" begin
     d = FT(0)
     T_sfc_guess = T_int
-    q_vap_sfc_guess = TD.q_vap_saturation(
+    q_sat = TD.q_vap_saturation(
         thermo_params,
         T_sfc_guess,
         ρ_int,
         TD.Liquid(),
     )
-
+    q_vap_sfc_guess = q_sat
     positional_default_args = (
         roughness_inputs = nothing,
         conf = SurfaceFluxes.default_surface_flux_config(eltype(param_set)),
@@ -46,9 +47,9 @@ u_sfc = (FT(0), FT(0))
 
     # Updates q_vap_sfc based on beta factor:
     # q_sfc = β * q_sat + (1 - β) * q_air
-    function land_update_q_vap_sfc(ζ, param_set, thermo_params, inputs, β)
+    function land_update_q_vap_sfc(ζ, param_set, thermo_params, inputs, β, q_sat)
         q_vap_int = inputs.q_tot_int - inputs.q_liq_int - inputs.q_ice_int
-        q = β * inputs.q_vap_sfc_guess + (1 - β) * q_vap_int # q_vap_sfc_guess is already the saturated value
+        q = β * q_sat + (1 - β) * q_vap_int
         return q
     end
 
@@ -56,7 +57,7 @@ u_sfc = (FT(0), FT(0))
     evap = FT.(zeros(length(β)))
     for i in 1:length(β)
         update_q_vap_sfc(ζ, param_set, thermo_params, inputs, T_sfc, args...) =
-            land_update_q_vap_sfc(ζ, param_set, thermo_params, inputs, β[i])
+            land_update_q_vap_sfc(ζ, param_set, thermo_params, inputs, β[i], q_sat)
         output = SurfaceFluxes.surface_fluxes(
             param_set,
             T_int,
@@ -257,12 +258,150 @@ end
             @test abs.(output.shf) < sqrt(eps(FT))
         end
     end
+end
 
-    # What we did before for comparison:
-    #    output_no_resistance = SurfaceFluxes.surface_fluxes(param_set, T_int, q_tot_int, ρ_int, T_canopy, q_canopy, Φ_sfc, Δz, d, u_int, u_sfc, roughness_inputs)
-    #    r_e = r_stomata_canopy + 1/(leaf_Cd * max(output_no_resistance.ustar, 1))/max(LAI, eps(FT))
-    #    r_h = 1/(leaf_Cd * max(output_no_resistance.ustar, 1))/max(LAI, eps(FT))
-    #    r_ae = 1/output_no_resistance.Ch/max(1, sqrt(u_int[1]^2 + u_int[2]^2))
-    #    pred_shf = output_no_resistance.shf *r_ae/(r_h+r_ae)
-    #    pred_e = output_no_resistance.evaporation *r_ae/(r_e+r_ae)
+
+@testset "Flux balance updates" begin
+    function update_T_scheme(
+        ζ,
+        param_set,
+        thermo_params,
+        inputs,
+        scheme,
+        u_star,
+        z_0m,
+        z_0h,
+        T̄,
+        κ,
+        d,
+        σ,
+        ϵ,
+        SW_n,
+        LW_d,
+    )
+        T_sfc = inputs.T_sfc_guess
+        T_atmos = inputs.T_int
+        ρ_atmos = inputs.ρ_int
+        q_vap_atmos = inputs.q_tot_int - inputs.q_liq_int - inputs.q_ice_int
+        q_sfc = TD.q_vap_saturation(thermo_params, T_sfc, ρ_atmos, FT(0), FT(0))
+        ρ_sfc = SurfaceFluxes.surface_density(
+            param_set,
+            T_atmos,
+            ρ_atmos,
+            T_sfc,
+            inputs.Δz,
+            inputs.q_tot_int,
+            inputs.q_liq_int,
+            inputs.q_ice_int,
+            q_sfc,
+        )
+        ∂q∂T = TD.∂q_vap_sat_∂T_from_L(
+            thermo_params,
+            q_sfc,
+            TD.latent_heat_vapor(thermo_params, T_sfc),
+            T_sfc,
+        )
+
+        g_h = SurfaceFluxes.heat_conductance(
+            param_set, ζ, u_star, inputs, z_0m, z_0h, scheme,
+        )
+        E = SurfaceFluxes.evaporation(
+            param_set,
+            inputs,
+            g_h,
+            q_vap_atmos,
+            q_sfc,
+            ρ_sfc,
+            inputs.moisture_model,
+        )
+        L = SurfaceFluxes.latent_heat_flux(
+            param_set, inputs, E, inputs.moisture_model,
+        )
+        H = SurfaceFluxes.sensible_heat_flux(
+            param_set, inputs, g_h, T_atmos, T_sfc, ρ_sfc, E,
+        )
+
+        _LH_v0 = TD.Parameters.LH_v0(thermo_params)
+        cp_d = TD.Parameters.cp_d(thermo_params)
+        ∂L∂T = ρ_sfc * g_h * _LH_v0 * ∂q∂T
+        ∂H∂T = ρ_sfc * g_h * cp_d
+        LW_n = ϵ * (LW_d - σ * T_sfc^4)
+        ∂LW_n∂T = -4 * ϵ * σ * T_sfc^3
+
+        # f(T) = L + H - R_n + κ (T_sfc - T̄) / d = 0
+        ΔT =
+            -(d * (-SW_n - LW_n + L + H) + κ * (T_sfc - T̄)) /
+            (d * (-∂LW_n∂T + ∂L∂T + ∂H∂T) + κ)
+        return T_sfc + ΔT
+    end
+
+    function update_q_scheme(
+        ζ,
+        param_set,
+        thermo_params,
+        inputs,
+        scheme,
+        T_sfc,
+        u_star,
+        z_0m,
+        z_0h,
+    )
+        # Saturated surface humidity at the temperature returned by update_T_scheme
+        return TD.q_vap_saturation(thermo_params, T_sfc, inputs.ρ_int, FT(0), FT(0))
+    end
+
+    positional_default_args = (
+        conf = SurfaceFluxes.default_surface_flux_config(eltype(param_set)),
+        scheme = SurfaceFluxes.PointValueScheme(),
+        solver_opts = nothing,
+        flux_specs = nothing,
+    )
+    d = FT(0.08)
+    T̄ = T_int - FT(3)
+    T_sfc_guess = T_int
+    q_vap_sfc_guess = TD.q_vap_saturation(
+        thermo_params,
+        T_sfc_guess,
+        ρ_int,
+        FT(0),
+        FT(0),
+    )
+    _σ = FT(5.67e-8) # Stefan–Boltzmann
+    ϵ = FT(0.99)
+    κ = FT(0.1)
+    SW_n = FT(500)
+    LW_d = FT(200)
+    displ = FT(0.0)
+    z_0m = FT(0.13)
+    z_0b = FT(0.1) * z_0m
+    roughness_inputs = SurfaceFluxes.ConstantRoughnessParams{FT}(z_0m, z_0b)
+    update_T(args...) =
+        update_T_scheme(args..., T̄, κ, d, _σ, ϵ, SW_n, LW_d)
+    output = SurfaceFluxes.surface_fluxes(
+        param_set,
+        T_int,
+        q_tot_int,
+        FT(0),
+        FT(0),
+        ρ_int,
+        T_sfc_guess,
+        q_vap_sfc_guess,
+        Φ_sfc,
+        Δz,
+        displ,
+        u_int,
+        u_sfc,
+        roughness_inputs,
+        positional_default_args...,
+        update_T,
+        update_q_scheme,
+    )
+
+    H = output.shf
+    L = output.lhf
+    LW_n = ϵ * (LW_d - _σ * output.T_sfc^4)
+    F_int = -κ * (output.T_sfc - T̄) / d
+    budget_residual = H + L - SW_n - LW_n - F_int
+    budget_scale = max(abs(H + L), abs(SW_n + LW_n), abs(F_int), FT(1))
+    @test abs(budget_residual) / budget_scale < FT(0.05)
 end

--- a/test/test_surface_fluxes_api.jl
+++ b/test/test_surface_fluxes_api.jl
@@ -80,6 +80,47 @@ const param_set = SFP.SurfaceFluxesParameters(FT, UF.BusingerParams)
     @test qs_calls[] > 0
     @test hooked_result.shf != base_result.shf
 
+    T_guess_history = FT[]
+    update_T_sfc_newton =
+        function (ζ, param_set, thermo_params, inputs, scheme, u_star, z0m, z0s)
+            push!(T_guess_history, inputs.T_sfc_guess)
+            return inputs.T_sfc_guess +
+                   FT(0.5) * (inputs.T_int - inputs.T_sfc_guess)
+        end
+
+    newton_result = SF.surface_fluxes(
+        param_set,
+        T_int,
+        q_tot_int,
+        FT(0),
+        FT(0),
+        ρ_int,
+        T_sfc_guess,
+        q_vap_sfc_guess,
+        FT(0),
+        FT(10),
+        FT(0),
+        (0, 0),
+        (0, 0),
+        nothing,
+        SF.default_surface_flux_config(FT),
+        SF.PointValueScheme(),
+        SF.SolverOptions{FT}(maxiter = 5, forced_fixed_iters = true),
+        nothing,
+        update_T_sfc_newton,
+        nothing,
+    )
+
+    @test length(T_guess_history) > 1
+    @test T_guess_history[1] == T_sfc_guess
+    @test all(
+        T_guess_history[i + 1] ≈
+        T_guess_history[i] + FT(0.5) * (T_int - T_guess_history[i]) for
+        i in 1:(length(T_guess_history) - 1)
+    )
+    # Synthetic callback test
+    @test newton_result.T_sfc > T_sfc_guess
+
     config = SF.SurfaceFluxConfig(
         SF.COARE3RoughnessParams{FT}(),
         SF.ConstantGustinessSpec(FT(0.5)),


### PR DESCRIPTION
Provides a new `solve_stability_param_cb` function, conditionally called when `update_x_sfc` callbacks are provided (so that X_sfc_guess is updated between iterations in the solver). Follows changes suggested in https://github.com/CliMA/SurfaceFluxes.jl/pull/245 by @kmdeck.